### PR TITLE
gx: update go-testutil

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-2.1.10: QmbiCMdwmmhif5axuGSHzYbPFGeKjLAuMY6JrGpVteHFsy
+2.1.11: QmWDAfS2ydVk86JqdwL9SDA2bhuNTLAsfV8fKfxdvLpRMi

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
       "version": "1.4.9"
     },
     {
-      "hash": "QmSXpwmggGd8fe7e9abqRuST7SqaZjrz3Cg5avMJbdmKGe",
+      "hash": "QmYazuWNCrC7LXeRt3utQuRsCDufpNM176rD1efuvF2pWJ",
       "name": "go-testutil",
-      "version": "1.1.8"
+      "version": "1.1.9"
     },
     {
       "author": "whyrusleeping",
@@ -41,6 +41,6 @@
   "license": "MIT",
   "name": "go-libp2p-kbucket",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "2.1.10"
+  "version": "2.1.11"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-libp2p-conn/pull/11
- https://github.com/libp2p/go-libp2p-connmgr/pull/2
- https://github.com/libp2p/go-libp2p-host/pull/5
- https://github.com/libp2p/go-libp2p-swarm/pull/27
- https://github.com/libp2p/go-libp2p-netutil/pull/7
- https://github.com/libp2p/go-libp2p-blankhost/pull/2
- https://github.com/libp2p/go-libp2p/pull/212


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace