### PR TITLE
Export CommonPrefixLen

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -94,7 +94,7 @@ func (b *Bucket) Split(cpl int, target ID) *Bucket {
 	e := b.list.Front()
 	for e != nil {
 		peerID := ConvertPeerID(e.Value.(peer.ID))
-		peerCPL := commonPrefixLen(peerID, target)
+		peerCPL := CommonPrefixLen(peerID, target)
 		if peerCPL > cpl {
 			cur := e
 			out.PushBack(e.Value)

--- a/table.go
+++ b/table.go
@@ -60,7 +60,7 @@ func NewRoutingTable(bucketsize int, localID ID, latency time.Duration, m pstore
 // Update adds or moves the given peer to the front of its respective bucket
 func (rt *RoutingTable) Update(p peer.ID) (evicted peer.ID, err error) {
 	peerID := ConvertPeerID(p)
-	cpl := commonPrefixLen(peerID, rt.local)
+	cpl := CommonPrefixLen(peerID, rt.local)
 
 	rt.tabLock.Lock()
 	defer rt.tabLock.Unlock()
@@ -117,7 +117,7 @@ func (rt *RoutingTable) Remove(p peer.ID) {
 	rt.tabLock.Lock()
 	defer rt.tabLock.Unlock()
 	peerID := ConvertPeerID(p)
-	cpl := commonPrefixLen(peerID, rt.local)
+	cpl := CommonPrefixLen(peerID, rt.local)
 
 	bucketID := cpl
 	if bucketID >= len(rt.Buckets) {
@@ -166,7 +166,7 @@ func (rt *RoutingTable) NearestPeer(id ID) peer.ID {
 
 // NearestPeers returns a list of the 'count' closest peers to the given ID
 func (rt *RoutingTable) NearestPeers(id ID, count int) []peer.ID {
-	cpl := commonPrefixLen(id, rt.local)
+	cpl := CommonPrefixLen(id, rt.local)
 
 	rt.tabLock.RLock()
 

--- a/table_test.go
+++ b/table_test.go
@@ -32,7 +32,7 @@ func TestBucket(t *testing.T) {
 	llist := b.list
 	for e := llist.Front(); e != nil; e = e.Next() {
 		p := ConvertPeerID(e.Value.(peer.ID))
-		cpl := commonPrefixLen(p, localID)
+		cpl := CommonPrefixLen(p, localID)
 		if cpl > 0 {
 			t.Fatalf("Split failed. found id with cpl > 0 in 0 bucket")
 		}
@@ -41,7 +41,7 @@ func TestBucket(t *testing.T) {
 	rlist := spl.list
 	for e := rlist.Front(); e != nil; e = e.Next() {
 		p := ConvertPeerID(e.Value.(peer.ID))
-		cpl := commonPrefixLen(p, localID)
+		cpl := CommonPrefixLen(p, localID)
 		if cpl == 0 {
 			t.Fatalf("Split failed. found id with cpl == 0 in non 0 bucket")
 		}
@@ -144,7 +144,7 @@ func TestTableEldestPreferred(t *testing.T) {
 	// generate size + 1 peers to saturate a bucket
 	peers := make([]peer.ID, 15)
 	for i := 0; i < 15; {
-		if p := tu.RandPeerIDFatal(t); commonPrefixLen(ConvertPeerID(local), ConvertPeerID(p)) == 0 {
+		if p := tu.RandPeerIDFatal(t); CommonPrefixLen(ConvertPeerID(local), ConvertPeerID(p)) == 0 {
 			peers[i] = p
 			i++
 		}

--- a/util.go
+++ b/util.go
@@ -34,7 +34,7 @@ func xor(a, b ID) ID {
 	return ID(u.XOR(a, b))
 }
 
-func commonPrefixLen(a, b ID) int {
+func CommonPrefixLen(a, b ID) int {
 	return ks.ZeroPrefixLen(u.XOR(a, b))
 }
 


### PR DESCRIPTION
`commonPrefixLen` is useful outside the package, for example [here](https://github.com/anacrolix/go-libp2p-dht-tool/blob/ad36b4be13b82f02a837d46667f3d276430d435c/main.go#L191).