### PR TITLE
Only call PeerRemoved when the peer was just removed

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -41,14 +41,16 @@ func (b *Bucket) Has(id peer.ID) bool {
 	return false
 }
 
-func (b *Bucket) Remove(id peer.ID) {
+func (b *Bucket) Remove(id peer.ID) bool {
 	b.lk.Lock()
 	defer b.lk.Unlock()
 	for e := b.list.Front(); e != nil; e = e.Next() {
 		if e.Value.(peer.ID) == id {
 			b.list.Remove(e)
+			return true
 		}
 	}
+	return false
 }
 
 func (b *Bucket) MoveToFront(id peer.ID) {

--- a/table.go
+++ b/table.go
@@ -125,8 +125,9 @@ func (rt *RoutingTable) Remove(p peer.ID) {
 	}
 
 	bucket := rt.Buckets[bucketID]
-	bucket.Remove(p)
-	rt.PeerRemoved(p)
+	if bucket.Remove(p) {
+		rt.PeerRemoved(p)
+	}
 }
 
 func (rt *RoutingTable) nextBucket() {


### PR DESCRIPTION
PeerRemoved was called even when the peer wasn't in the routing table. This was generating bogus routing table churn metrics.