### PR TITLE
fix: copyPeersFromList may cause peerArr be empty

### DIFF
--- a/sorting.go
+++ b/sorting.go
@@ -26,7 +26,7 @@ func (p peerSorterArr) Less(a, b int) bool {
 
 func copyPeersFromList(target ID, peerArr peerSorterArr, peerList *list.List) peerSorterArr {
 	if cap(peerArr) < len(peerArr)+peerList.Len() {
-		newArr := make(peerSorterArr, 0, len(peerArr)+peerList.Len())
+		newArr := make(peerSorterArr, len(peerArr), len(peerArr)+peerList.Len())
 		copy(newArr, peerArr)
 		peerArr = newArr
 	}


### PR DESCRIPTION
the builtin function `copy` will use  the minimum of len(src) and len(dst).  so this code use zero length for newArr will not copy the peerArr content.