### PR TITLE
dep: use a faster sha256 library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/libp2p/go-libp2p-peer v0.0.1
 	github.com/libp2p/go-libp2p-peerstore v0.0.1
 	github.com/libp2p/go-testutil v0.0.1
+	github.com/minio/sha256-simd v0.0.0-20190131020904-2d45a736cd16
 )

--- a/keyspace/xor.go
+++ b/keyspace/xor.go
@@ -2,11 +2,11 @@ package keyspace
 
 import (
 	"bytes"
-	"crypto/sha256"
 	"math/big"
 	"math/bits"
 
 	u "github.com/ipfs/go-ipfs-util"
+	sha256 "github.com/minio/sha256-simd"
 )
 
 // XORKeySpace is a KeySpace which:

--- a/util.go
+++ b/util.go
@@ -2,12 +2,12 @@ package kbucket
 
 import (
 	"bytes"
-	"crypto/sha256"
 	"errors"
 
 	u "github.com/ipfs/go-ipfs-util"
 	ks "github.com/libp2p/go-libp2p-kbucket/keyspace"
 	peer "github.com/libp2p/go-libp2p-peer"
+	sha256 "github.com/minio/sha256-simd"
 )
 
 // Returned if a routing table query returns no results. This is NOT expected


### PR DESCRIPTION
This is the one we're using in secio/multihash.