### PR TITLE
Disassociate RT membership from connectivity

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -4,8 +4,6 @@ package kbucket
 
 import (
 	"container/list"
-	"sync"
-
 	"github.com/libp2p/go-libp2p-core/peer"
 )
 
@@ -26,8 +24,11 @@ type PeerInfo struct {
 }
 
 // bucket holds a list of peers.
+// we synchronize on the Routing Table lock for all access to the bucket
+// and so do not need any locks in the bucket.
+// if we want/need to avoid locking the table for accessing a bucket in the future,
+// it WILL be the caller's responsibility to synchronize all access to a bucket.
 type bucket struct {
-	lk   sync.RWMutex
 	list *list.List
 }
 
@@ -40,8 +41,6 @@ func newBucket() *bucket {
 // returns all peers in the bucket
 // it is safe for the caller to modify the returned objects as it is a defensive copy
 func (b *bucket) peers() []PeerInfo {
-	b.lk.RLock()
-	defer b.lk.RUnlock()
 	var ps []PeerInfo
 	for e := b.list.Front(); e != nil; e = e.Next() {
 		p := e.Value.(*PeerInfo)
@@ -52,8 +51,6 @@ func (b *bucket) peers() []PeerInfo {
 
 // return the Ids of all the peers in the bucket.
 func (b *bucket) peerIds() []peer.ID {
-	b.lk.RLock()
-	defer b.lk.RUnlock()
 	ps := make([]peer.ID, 0, b.list.Len())
 	for e := b.list.Front(); e != nil; e = e.Next() {
 		p := e.Value.(*PeerInfo)
@@ -65,8 +62,6 @@ func (b *bucket) peerIds() []peer.ID {
 // returns the peer with the given Id if it exists
 // returns nil if the peerId does not exist
 func (b *bucket) getPeer(p peer.ID) *PeerInfo {
-	b.lk.RLock()
-	defer b.lk.RUnlock()
 	for e := b.list.Front(); e != nil; e = e.Next() {
 		if e.Value.(*PeerInfo).Id == p {
 			return e.Value.(*PeerInfo)
@@ -78,8 +73,6 @@ func (b *bucket) getPeer(p peer.ID) *PeerInfo {
 // removes the peer with the given Id from the bucket.
 // returns true if successful, false otherwise.
 func (b *bucket) remove(id peer.ID) bool {
-	b.lk.Lock()
-	defer b.lk.Unlock()
 	for e := b.list.Front(); e != nil; e = e.Next() {
 		if e.Value.(*PeerInfo).Id == id {
 			b.list.Remove(e)
@@ -90,8 +83,6 @@ func (b *bucket) remove(id peer.ID) bool {
 }
 
 func (b *bucket) moveToFront(id peer.ID) {
-	b.lk.Lock()
-	defer b.lk.Unlock()
 
 	for e := b.list.Front(); e != nil; e = e.Next() {
 		if e.Value.(*PeerInfo).Id == id {
@@ -101,14 +92,10 @@ func (b *bucket) moveToFront(id peer.ID) {
 }
 
 func (b *bucket) pushFront(p *PeerInfo) {
-	b.lk.Lock()
 	b.list.PushFront(p)
-	b.lk.Unlock()
 }
 
 func (b *bucket) len() int {
-	b.lk.RLock()
-	defer b.lk.RUnlock()
 	return b.list.Len()
 }
 
@@ -116,9 +103,6 @@ func (b *bucket) len() int {
 // peers with CPL equal to cpl, the returned bucket will have peers with CPL
 // greater than cpl (returned bucket has closer peers)
 func (b *bucket) split(cpl int, target ID) *bucket {
-	b.lk.Lock()
-	defer b.lk.Unlock()
-
 	out := list.New()
 	newbuck := newBucket()
 	newbuck.list = out

--- a/bucket.go
+++ b/bucket.go
@@ -9,45 +9,93 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 )
 
-// Bucket holds a list of peers.
-type Bucket struct {
+// PeerState is the state of the peer as seen by the Routing Table.
+type PeerState int
+
+const (
+	// PeerStateActive indicates that we know the peer is active/alive.
+	PeerStateActive PeerState = iota
+	// PeerStateMissing indicates that we do not know the state of the peer.
+	PeerStateMissing
+)
+
+// PeerInfo holds all related information for a peer in the K-Bucket.
+type PeerInfo struct {
+	Id    peer.ID
+	State PeerState
+}
+
+// bucket holds a list of peers.
+type bucket struct {
 	lk   sync.RWMutex
 	list *list.List
 }
 
-func newBucket() *Bucket {
-	b := new(Bucket)
+func newBucket() *bucket {
+	b := new(bucket)
 	b.list = list.New()
 	return b
 }
 
-func (b *Bucket) Peers() []peer.ID {
+// returns all peers in the bucket
+func (b *bucket) peers() []PeerInfo {
 	b.lk.RLock()
 	defer b.lk.RUnlock()
-	ps := make([]peer.ID, 0, b.list.Len())
+	var ps []PeerInfo
 	for e := b.list.Front(); e != nil; e = e.Next() {
-		id := e.Value.(peer.ID)
-		ps = append(ps, id)
+		p := e.Value.(PeerInfo)
+		ps = append(ps, p)
 	}
 	return ps
 }
 
-func (b *Bucket) Has(id peer.ID) bool {
+// return the Ids of all the peers in the bucket.
+func (b *bucket) peerIds() []peer.ID {
+	b.lk.RLock()
+	defer b.lk.RUnlock()
+	ps := make([]peer.ID, 0, b.list.Len())
+	for e := b.list.Front(); e != nil; e = e.Next() {
+		p := e.Value.(PeerInfo)
+		ps = append(ps, p.Id)
+	}
+	return ps
+}
+
+// returns the peer with the given Id and true if peer exists
+// returns false if the peerId does not exist
+func (b *bucket) getPeer(p peer.ID) (PeerInfo, bool) {
 	b.lk.RLock()
 	defer b.lk.RUnlock()
 	for e := b.list.Front(); e != nil; e = e.Next() {
-		if e.Value.(peer.ID) == id {
+		if e.Value.(PeerInfo).Id == p {
+			return e.Value.(PeerInfo), true
+		}
+	}
+	return PeerInfo{}, false
+}
+
+// replaces the peer based on the Id.
+// returns true if the replace was successful, false otherwise.
+func (b *bucket) replace(p PeerInfo) bool {
+	b.lk.Lock()
+	defer b.lk.Unlock()
+	for e := b.list.Front(); e != nil; e = e.Next() {
+		if e.Value.(PeerInfo).Id == p.Id {
+			b.list.Remove(e)
+			b.list.PushBack(p)
 			return true
 		}
 	}
 	return false
 }
 
-func (b *Bucket) Remove(id peer.ID) bool {
+// removes the peer with the given Id from the bucket.
+// returns true if successful, false otherwise.
+func (b *bucket) remove(id peer.ID) bool {
 	b.lk.Lock()
 	defer b.lk.Unlock()
 	for e := b.list.Front(); e != nil; e = e.Next() {
-		if e.Value.(peer.ID) == id {
+		if e.Value.(PeerInfo).Id == id {
 			b.list.Remove(e)
 			return true
 		}
@@ -55,40 +103,33 @@ func (b *Bucket) Remove(id peer.ID) bool {
 	return false
 }
 
-func (b *Bucket) MoveToFront(id peer.ID) {
+func (b *bucket) moveToFront(id peer.ID) {
 	b.lk.Lock()
 	defer b.lk.Unlock()
+
 	for e := b.list.Front(); e != nil; e = e.Next() {
-		if e.Value.(peer.ID) == id {
+		if e.Value.(PeerInfo).Id == id {
 			b.list.MoveToFront(e)
 		}
 	}
 }
 
-func (b *Bucket) PushFront(p peer.ID) {
+func (b *bucket) pushFront(p PeerInfo) {
 	b.lk.Lock()
 	b.list.PushFront(p)
 	b.lk.Unlock()
 }
 
-func (b *Bucket) PopBack() peer.ID {
-	b.lk.Lock()
-	defer b.lk.Unlock()
-	last := b.list.Back()
-	b.list.Remove(last)
-	return last.Value.(peer.ID)
-}
-
-func (b *Bucket) Len() int {
+func (b *bucket) len() int {
 	b.lk.RLock()
 	defer b.lk.RUnlock()
 	return b.list.Len()
 }
 
-// Split splits a buckets peers into two buckets, the methods receiver will have
+// splits a buckets peers into two buckets, the methods receiver will have
 // peers with CPL equal to cpl, the returned bucket will have peers with CPL
 // greater than cpl (returned bucket has closer peers)
-func (b *Bucket) Split(cpl int, target ID) *Bucket {
+func (b *bucket) split(cpl int, target ID) *bucket {
 	b.lk.Lock()
 	defer b.lk.Unlock()
 
@@ -97,7 +138,7 @@ func (b *Bucket) Split(cpl int, target ID) *Bucket {
 	newbuck.list = out
 	e := b.list.Front()
 	for e != nil {
-		peerID := ConvertPeerID(e.Value.(peer.ID))
+		peerID := ConvertPeerID(e.Value.(PeerInfo).Id)
 		peerCPL := CommonPrefixLen(peerID, target)
 		if peerCPL > cpl {
 			cur := e

--- a/cpl_replacement_cache.go
+++ b/cpl_replacement_cache.go
@@ -1,0 +1,98 @@
+package kbucket
+
+import (
+	"sync"
+
+	"github.com/libp2p/go-libp2p-core/peer"
+
+	"github.com/wangjia184/sortedset"
+)
+
+// TODO Should ideally use a Circular queue for this
+// maintains a bounded, de-duplicated and FIFO peer candidate queue for each Cpl
+type cplReplacementCache struct {
+	localPeer    ID
+	maxQueueSize int
+
+	sync.Mutex
+	candidates map[uint]*sortedset.SortedSet // candidates for a Cpl
+}
+
+func newCplReplacementCache(localPeer ID, maxQueueSize int) *cplReplacementCache {
+	return &cplReplacementCache{
+		localPeer:    localPeer,
+		maxQueueSize: maxQueueSize,
+		candidates:   make(map[uint]*sortedset.SortedSet),
+	}
+}
+
+// pushes a candidate to the end of the queue for the corresponding Cpl
+// returns false if the queue is full or it already has the peer
+// returns true if was successfully added
+func (c *cplReplacementCache) push(p peer.ID) bool {
+	c.Lock()
+	defer c.Unlock()
+
+	// create queue if not created
+	cpl := uint(CommonPrefixLen(c.localPeer, ConvertPeerID(p)))
+	if c.candidates[cpl] == nil {
+		c.candidates[cpl] = sortedset.New()
+	}
+
+	q := c.candidates[cpl]
+
+	// queue is full
+	if (q.GetCount()) >= c.maxQueueSize {
+		return false
+	}
+	// queue already has the peer
+	if q.GetByKey(string(p)) != nil {
+		return false
+	}
+
+	// push
+	q.AddOrUpdate(string(p), sortedset.SCORE(q.GetCount()+1), nil)
+	return true
+}
+
+// pops a candidate from the top of the candidate queue for the given Cpl
+// returns false if the queue is empty
+// returns the peerId and true if successful
+func (c *cplReplacementCache) pop(cpl uint) (peer.ID, bool) {
+	c.Lock()
+	c.Unlock()
+
+	q := c.candidates[cpl]
+	if q != nil && q.GetCount() > 0 {
+		n := q.PopMin()
+
+		// delete the queue if it's empty
+		if q.GetCount() == 0 {
+			delete(c.candidates, cpl)
+		}
+
+		return peer.ID(n.Key()), true
+	}
+	return "", false
+}
+
+// removes a given peer if it's present
+// returns false if the peer is absent
+func (c *cplReplacementCache) remove(p peer.ID) bool {
+	c.Lock()
+	defer c.Unlock()
+
+	cpl := uint(CommonPrefixLen(c.localPeer, ConvertPeerID(p)))
+	q := c.candidates[cpl]
+	if q != nil {
+		q.Remove(string(p))
+
+		// remove the queue if it's empty
+		if q.GetCount() == 0 {
+			delete(c.candidates, cpl)
+		}
+
+		return true
+	}
+	return false
+}

--- a/cpl_replacement_cache_test.go
+++ b/cpl_replacement_cache_test.go
@@ -1,0 +1,82 @@
+package kbucket
+
+import (
+	"testing"
+
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p-core/test"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCandidateQueue(t *testing.T) {
+	t.Parallel()
+
+	maxQSize := 2
+	local := ConvertPeerID(test.RandPeerIDFatal(t))
+	c := newCplReplacementCache(local, maxQSize)
+
+	// pop an empty queue fails
+	p, b := c.pop(1)
+	require.Empty(t, p)
+	require.False(t, b)
+
+	// push two elements to an empty queue works
+	testPeer1 := genPeer(t, local, 1)
+	testPeer2 := genPeer(t, local, 1)
+
+	// pushing first peer works
+	require.True(t, c.push(testPeer1))
+	// pushing a duplicate fails
+	require.False(t, c.push(testPeer1))
+	// pushing another peers works
+	require.True(t, c.push(testPeer2))
+
+	// popping the above pushes works
+	p, b = c.pop(1)
+	require.True(t, b)
+	require.Equal(t, testPeer1, p)
+	p, b = c.pop(1)
+	require.True(t, b)
+	require.Equal(t, testPeer2, p)
+
+	// pushing & popping again works
+	require.True(t, c.push(testPeer1))
+	require.True(t, c.push(testPeer2))
+	p, b = c.pop(1)
+	require.True(t, b)
+	require.Equal(t, testPeer1, p)
+	p, b = c.pop(1)
+	require.True(t, b)
+	require.Equal(t, testPeer2, p)
+
+	// fill up a queue
+	p1 := genPeer(t, local, 2)
+	p2 := genPeer(t, local, 2)
+	require.True(t, c.push(p1))
+	require.True(t, c.push(p2))
+
+	// push should not work on a full queue
+	p3 := genPeer(t, local, 2)
+	require.False(t, c.push(p3))
+
+	// remove a peer & verify it's been removed
+	require.NotNil(t, c.candidates[2].GetByKey(string(p2)))
+	require.True(t, c.remove(p2))
+	c.Lock()
+	require.Nil(t, c.candidates[2].GetByKey(string(p2)))
+	c.Unlock()
+
+	// now push should work
+	require.True(t, c.push(p3))
+}
+
+func genPeer(t *testing.T, local ID, cpl int) peer.ID {
+	var p peer.ID
+	for {
+		p = test.RandPeerIDFatal(t)
+		if CommonPrefixLen(local, ConvertPeerID(p)) == cpl {
+			return p
+		}
+	}
+}

--- a/cpl_replacement_cache_test.go
+++ b/cpl_replacement_cache_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCandidateQueue(t *testing.T) {
+func TestCplReplacementCache(t *testing.T) {
 	t.Parallel()
 
 	maxQSize := 2
@@ -61,14 +61,19 @@ func TestCandidateQueue(t *testing.T) {
 	require.False(t, c.push(p3))
 
 	// remove a peer & verify it's been removed
-	require.NotNil(t, c.candidates[2].GetByKey(string(p2)))
-	require.True(t, c.remove(p2))
+	p4 := genPeer(t, local, 0)
+	require.True(t, c.push(p4))
+
 	c.Lock()
-	require.Nil(t, c.candidates[2].GetByKey(string(p2)))
+	require.Len(t, c.candidates[0], 1)
+	require.True(t, c.candidates[0][0] == p4)
 	c.Unlock()
 
-	// now push should work
-	require.True(t, c.push(p3))
+	require.True(t, c.remove(p4))
+
+	c.Lock()
+	require.Len(t, c.candidates[0], 0)
+	c.Unlock()
 }
 
 func genPeer(t *testing.T, local ID, cpl int) peer.ID {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/libp2p/go-libp2p-kbucket
 require (
 	github.com/ipfs/go-ipfs-util v0.0.1
 	github.com/ipfs/go-log v0.0.1
+	github.com/jbenet/goprocess v0.1.3
 	github.com/libp2p/go-libp2p-core v0.3.0
 	github.com/libp2p/go-libp2p-peerstore v0.1.4
 	github.com/minio/sha256-simd v0.1.1

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/minio/sha256-simd v0.1.1
 	github.com/multiformats/go-multihash v0.0.13
 	github.com/stretchr/testify v1.4.0
+	github.com/wangjia184/sortedset v0.0.0-20160527075905-f5d03557ba30
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -174,6 +174,8 @@ github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/opentracing/opentracing-go v1.0.2 h1:3jA2P6O1F9UOrWVpwrIo17pu01KWvNWg4X946/Y5Zwg=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -204,6 +206,8 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
+github.com/wangjia184/sortedset v0.0.0-20160527075905-f5d03557ba30 h1:kZiWylALnUy4kzoKJemjH8eqwCl3RjW1r1ITCjjW7G8=
+github.com/wangjia184/sortedset v0.0.0-20160527075905-f5d03557ba30/go.mod h1:YkocrP2K2tcw938x9gCOmT5G5eCD6jsTz0SZuyAqwIE=
 github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1/go.mod h1:8UvriyWtv5Q5EOgjHaSseUEdkQfvwFv1I/In/O2M9gc=
 github.com/whyrusleeping/go-logging v0.0.0-20170515211332-0457bb6b88fc h1:9lDbC6Rz4bwmou+oE6Dt4Cb2BGMur5eR/GYptkKUVHo=
 github.com/whyrusleeping/go-logging v0.0.0-20170515211332-0457bb6b88fc/go.mod h1:bopw91TMyo8J3tvftk8xmU2kPmlrt4nScJQZU2hE5EM=

--- a/options.go
+++ b/options.go
@@ -11,7 +11,8 @@ type Option func(*Options) error
 // Options is a structure containing all the functional options that can be used when constructing a Routing Table.
 type Options struct {
 	TableCleanup struct {
-		PeersForValidationFnc PeerSelectionFnc
+		PeerValidationFnc     PeerValidationFunc
+		PeersForValidationFnc PeerSelectionFunc
 		PeerValidationTimeout time.Duration
 		Interval              time.Duration
 	}
@@ -27,8 +28,17 @@ func (o *Options) Apply(opts ...Option) error {
 	return nil
 }
 
+// PeerValidationFnc configures the Peer Validation function used for RT cleanup.
+// Not configuring this disables Routing Table cleanup.
+func PeerValidationFnc(f PeerValidationFunc) Option {
+	return func(o *Options) error {
+		o.TableCleanup.PeerValidationFnc = f
+		return nil
+	}
+}
+
 // PeersForValidationFnc configures the function that will be used to select the peers that need to be validated during cleanup.
-func PeersForValidationFnc(f PeerSelectionFnc) Option {
+func PeersForValidationFnc(f PeerSelectionFunc) Option {
 	return func(o *Options) error {
 		o.TableCleanup.PeersForValidationFnc = f
 		return nil

--- a/options.go
+++ b/options.go
@@ -5,21 +5,21 @@ import (
 	"time"
 )
 
-// Option is the Routing Table functional option type.
-type Option func(*Options) error
+// option is the Routing Table functional option type.
+type option func(*options) error
 
-// Options is a structure containing all the functional options that can be used when constructing a Routing Table.
-type Options struct {
-	TableCleanup struct {
-		PeerValidationFnc     PeerValidationFunc
-		PeersForValidationFnc PeerSelectionFunc
-		PeerValidationTimeout time.Duration
-		Interval              time.Duration
+// options is a structure containing all the functional options that can be used when constructing a Routing Table.
+type options struct {
+	tableCleanup struct {
+		peerValidationFnc     PeerValidationFunc
+		peersForValidationFnc PeerSelectionFunc
+		peerValidationTimeout time.Duration
+		interval              time.Duration
 	}
 }
 
-// Apply applies the given options to this Option.
-func (o *Options) Apply(opts ...Option) error {
+// Apply applies the given options to this option.
+func (o *options) Apply(opts ...option) error {
 	for i, opt := range opts {
 		if err := opt(o); err != nil {
 			return fmt.Errorf("routing table option %d failed: %s", i, err)
@@ -30,45 +30,45 @@ func (o *Options) Apply(opts ...Option) error {
 
 // PeerValidationFnc configures the Peer Validation function used for RT cleanup.
 // Not configuring this disables Routing Table cleanup.
-func PeerValidationFnc(f PeerValidationFunc) Option {
-	return func(o *Options) error {
-		o.TableCleanup.PeerValidationFnc = f
+func PeerValidationFnc(f PeerValidationFunc) option {
+	return func(o *options) error {
+		o.tableCleanup.peerValidationFnc = f
 		return nil
 	}
 }
 
 // PeersForValidationFnc configures the function that will be used to select the peers that need to be validated during cleanup.
-func PeersForValidationFnc(f PeerSelectionFunc) Option {
-	return func(o *Options) error {
-		o.TableCleanup.PeersForValidationFnc = f
+func PeersForValidationFnc(f PeerSelectionFunc) option {
+	return func(o *options) error {
+		o.tableCleanup.peersForValidationFnc = f
 		return nil
 	}
 }
 
 // TableCleanupInterval configures the interval between two runs of the Routing Table cleanup routine.
-func TableCleanupInterval(i time.Duration) Option {
-	return func(o *Options) error {
-		o.TableCleanup.Interval = i
+func TableCleanupInterval(i time.Duration) option {
+	return func(o *options) error {
+		o.tableCleanup.interval = i
 		return nil
 	}
 }
 
 // PeerValidationTimeout sets the timeout for a single peer validation during cleanup.
-func PeerValidationTimeout(timeout time.Duration) Option {
-	return func(o *Options) error {
-		o.TableCleanup.PeerValidationTimeout = timeout
+func PeerValidationTimeout(timeout time.Duration) option {
+	return func(o *options) error {
+		o.tableCleanup.peerValidationTimeout = timeout
 		return nil
 	}
 }
 
 // Defaults are the default options. This option will be automatically
 // prepended to any options you pass to the Routing Table constructor.
-var Defaults = func(o *Options) error {
-	o.TableCleanup.PeerValidationTimeout = 30 * time.Second
-	o.TableCleanup.Interval = 2 * time.Minute
+var Defaults = func(o *options) error {
+	o.tableCleanup.peerValidationTimeout = 30 * time.Second
+	o.tableCleanup.interval = 2 * time.Minute
 
 	// default selector function selects all peers that are in missing state.
-	o.TableCleanup.PeersForValidationFnc = func(peers []PeerInfo) []PeerInfo {
+	o.tableCleanup.peersForValidationFnc = func(peers []PeerInfo) []PeerInfo {
 		var selectedPeers []PeerInfo
 		for _, p := range peers {
 			if p.State == PeerStateMissing {

--- a/options.go
+++ b/options.go
@@ -1,0 +1,72 @@
+package kbucket
+
+import (
+	"fmt"
+	"time"
+)
+
+// Option is the Routing Table functional option type.
+type Option func(*Options) error
+
+// Options is a structure containing all the functional options that can be used when constructing a Routing Table.
+type Options struct {
+	TableCleanup struct {
+		PeersForValidationFnc PeerSelectionFnc
+		PeerValidationTimeout time.Duration
+		Interval              time.Duration
+	}
+}
+
+// Apply applies the given options to this Option.
+func (o *Options) Apply(opts ...Option) error {
+	for i, opt := range opts {
+		if err := opt(o); err != nil {
+			return fmt.Errorf("routing table option %d failed: %s", i, err)
+		}
+	}
+	return nil
+}
+
+// PeersForValidationFnc configures the function that will be used to select the peers that need to be validated during cleanup.
+func PeersForValidationFnc(f PeerSelectionFnc) Option {
+	return func(o *Options) error {
+		o.TableCleanup.PeersForValidationFnc = f
+		return nil
+	}
+}
+
+// TableCleanupInterval configures the interval between two runs of the Routing Table cleanup routine.
+func TableCleanupInterval(i time.Duration) Option {
+	return func(o *Options) error {
+		o.TableCleanup.Interval = i
+		return nil
+	}
+}
+
+// PeerValidationTimeout sets the timeout for a single peer validation during cleanup.
+func PeerValidationTimeout(timeout time.Duration) Option {
+	return func(o *Options) error {
+		o.TableCleanup.PeerValidationTimeout = timeout
+		return nil
+	}
+}
+
+// Defaults are the default options. This option will be automatically
+// prepended to any options you pass to the Routing Table constructor.
+var Defaults = func(o *Options) error {
+	o.TableCleanup.PeerValidationTimeout = 30 * time.Second
+	o.TableCleanup.Interval = 2 * time.Minute
+
+	// default selector function selects all peers that are in missing state.
+	o.TableCleanup.PeersForValidationFnc = func(peers []PeerInfo) []PeerInfo {
+		var selectedPeers []PeerInfo
+		for _, p := range peers {
+			if p.State == PeerStateMissing {
+				selectedPeers = append(selectedPeers, p)
+			}
+		}
+		return selectedPeers
+	}
+
+	return nil
+}

--- a/sorting.go
+++ b/sorting.go
@@ -36,7 +36,7 @@ func (pds *peerDistanceSorter) appendPeer(p peer.ID) {
 // Append the peer.ID values in the list to the sorter's slice. It may no longer be sorted.
 func (pds *peerDistanceSorter) appendPeersFromList(l *list.List) {
 	for e := l.Front(); e != nil; e = e.Next() {
-		pds.appendPeer(e.Value.(peer.ID))
+		pds.appendPeer(e.Value.(PeerInfo).Id)
 	}
 }
 

--- a/sorting.go
+++ b/sorting.go
@@ -36,7 +36,7 @@ func (pds *peerDistanceSorter) appendPeer(p peer.ID) {
 // Append the peer.ID values in the list to the sorter's slice. It may no longer be sorted.
 func (pds *peerDistanceSorter) appendPeersFromList(l *list.List) {
 	for e := l.Front(); e != nil; e = e.Next() {
-		pds.appendPeer(e.Value.(PeerInfo).Id)
+		pds.appendPeer(e.Value.(*PeerInfo).Id)
 	}
 }
 

--- a/table.go
+++ b/table.go
@@ -458,12 +458,10 @@ func (rt *RoutingTable) Print() {
 	for i, b := range rt.buckets {
 		fmt.Printf("\tbucket: %d\n", i)
 
-		b.lk.RLock()
 		for e := b.list.Front(); e != nil; e = e.Next() {
 			p := e.Value.(peer.ID)
 			fmt.Printf("\t\t- %s %s\n", p.Pretty(), rt.metrics.LatencyEWMA(p).String())
 		}
-		b.lk.RUnlock()
 	}
 	rt.tabLock.RUnlock()
 }

--- a/table.go
+++ b/table.go
@@ -87,10 +87,10 @@ type RoutingTable struct {
 // NewRoutingTable creates a new routing table with a given bucketsize, local ID, and latency tolerance.
 // Passing a nil PeerValidationFunc disables periodic table cleanup.
 func NewRoutingTable(bucketsize int, localID ID, latency time.Duration, m peerstore.Metrics,
-	options ...Option) (*RoutingTable, error) {
+	opts ...option) (*RoutingTable, error) {
 
-	var cfg Options
-	if err := cfg.Apply(append([]Option{Defaults}, options...)...); err != nil {
+	var cfg options
+	if err := cfg.Apply(append([]option{Defaults}, opts...)...); err != nil {
 		return nil, err
 	}
 
@@ -108,10 +108,10 @@ func NewRoutingTable(bucketsize int, localID ID, latency time.Duration, m peerst
 		PeerRemoved: func(peer.ID) {},
 		PeerAdded:   func(peer.ID) {},
 
-		peerValidationFnc:     cfg.TableCleanup.PeerValidationFnc,
-		peersForValidationFnc: cfg.TableCleanup.PeersForValidationFnc,
-		peerValidationTimeout: cfg.TableCleanup.PeerValidationTimeout,
-		tableCleanupInterval:  cfg.TableCleanup.Interval,
+		peerValidationFnc:     cfg.tableCleanup.peerValidationFnc,
+		peersForValidationFnc: cfg.tableCleanup.peersForValidationFnc,
+		peerValidationTimeout: cfg.tableCleanup.peerValidationTimeout,
+		tableCleanupInterval:  cfg.tableCleanup.interval,
 	}
 
 	rt.cplReplacementCache = newCplReplacementCache(rt.local, rt.bucketsize)

--- a/table_test.go
+++ b/table_test.go
@@ -70,11 +70,10 @@ func TestBucket(t *testing.T) {
 
 func TestGenRandPeerID(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
 	local := test.RandPeerIDFatal(t)
 	m := pstore.NewMetrics()
-	rt, err := NewRoutingTable(ctx, 1, ConvertPeerID(local), time.Hour, m, PeerValidationFnc(PeerAlwaysValidFnc))
+	rt, err := NewRoutingTable(1, ConvertPeerID(local), time.Hour, m, PeerValidationFnc(PeerAlwaysValidFnc))
 	require.NoError(t, err)
 
 	// generate above maxCplForRefresh fails
@@ -93,11 +92,9 @@ func TestGenRandPeerID(t *testing.T) {
 
 func TestRefreshAndGetTrackedCpls(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
-
 	local := test.RandPeerIDFatal(t)
 	m := pstore.NewMetrics()
-	rt, err := NewRoutingTable(ctx, 1, ConvertPeerID(local), time.Hour, m, PeerValidationFnc(PeerAlwaysValidFnc))
+	rt, err := NewRoutingTable(1, ConvertPeerID(local), time.Hour, m, PeerValidationFnc(PeerAlwaysValidFnc))
 	require.NoError(t, err)
 
 	// push cpl's for tracking
@@ -123,11 +120,10 @@ func TestRefreshAndGetTrackedCpls(t *testing.T) {
 
 func TestHandlePeerDead(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
 	local := test.RandPeerIDFatal(t)
 	m := pstore.NewMetrics()
-	rt, err := NewRoutingTable(ctx, 2, ConvertPeerID(local), time.Hour, m, PeerValidationFnc(PeerAlwaysValidFnc))
+	rt, err := NewRoutingTable(2, ConvertPeerID(local), time.Hour, m, PeerValidationFnc(PeerAlwaysValidFnc))
 	require.NoError(t, err)
 
 	// push 3 peers  -> 2 for the first bucket, and 1 as candidates
@@ -161,11 +157,10 @@ func TestHandlePeerDead(t *testing.T) {
 
 func TestTableCallbacks(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
 	local := test.RandPeerIDFatal(t)
 	m := pstore.NewMetrics()
-	rt, err := NewRoutingTable(ctx, 10, ConvertPeerID(local), time.Hour, m, PeerValidationFnc(PeerAlwaysValidFnc))
+	rt, err := NewRoutingTable(10, ConvertPeerID(local), time.Hour, m, PeerValidationFnc(PeerAlwaysValidFnc))
 	require.NoError(t, err)
 
 	peers := make([]peer.ID, 100)
@@ -210,11 +205,10 @@ func TestTableCallbacks(t *testing.T) {
 
 func TestHandlePeerDisconnect(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
 	local := test.RandPeerIDFatal(t)
 	m := pstore.NewMetrics()
-	rt, err := NewRoutingTable(ctx, 10, ConvertPeerID(local), time.Hour, m, PeerValidationFnc(PeerAlwaysValidFnc))
+	rt, err := NewRoutingTable(10, ConvertPeerID(local), time.Hour, m, PeerValidationFnc(PeerAlwaysValidFnc))
 	require.NoError(t, err)
 
 	p := test.RandPeerIDFatal(t)
@@ -241,11 +235,10 @@ func TestHandlePeerDisconnect(t *testing.T) {
 // Right now, this just makes sure that it doesnt hang or crash
 func TestHandlePeerAlive(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
 	local := test.RandPeerIDFatal(t)
 	m := pstore.NewMetrics()
-	rt, err := NewRoutingTable(ctx, 10, ConvertPeerID(local), time.Hour, m, PeerValidationFnc(PeerAlwaysValidFnc))
+	rt, err := NewRoutingTable(10, ConvertPeerID(local), time.Hour, m, PeerValidationFnc(PeerAlwaysValidFnc))
 	require.NoError(t, err)
 
 	peers := make([]peer.ID, 100)
@@ -269,11 +262,10 @@ func TestHandlePeerAlive(t *testing.T) {
 
 func TestTableFind(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
 	local := test.RandPeerIDFatal(t)
 	m := pstore.NewMetrics()
-	rt, err := NewRoutingTable(ctx, 10, ConvertPeerID(local), time.Hour, m, PeerValidationFnc(PeerAlwaysValidFnc))
+	rt, err := NewRoutingTable(10, ConvertPeerID(local), time.Hour, m, PeerValidationFnc(PeerAlwaysValidFnc))
 	require.NoError(t, err)
 
 	peers := make([]peer.ID, 100)
@@ -291,11 +283,10 @@ func TestTableFind(t *testing.T) {
 
 func TestCandidateAddition(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
 	local := test.RandPeerIDFatal(t)
 	m := pstore.NewMetrics()
-	rt, err := NewRoutingTable(ctx, 3, ConvertPeerID(local), time.Hour, m, PeerValidationFnc(PeerAlwaysValidFnc))
+	rt, err := NewRoutingTable(3, ConvertPeerID(local), time.Hour, m, PeerValidationFnc(PeerAlwaysValidFnc))
 	require.NoError(t, err)
 
 	// generate 6 peers for the first bucket, 3 to push to it, and 3 as candidates
@@ -322,11 +313,10 @@ func TestCandidateAddition(t *testing.T) {
 
 func TestTableEldestPreferred(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
 	local := test.RandPeerIDFatal(t)
 	m := pstore.NewMetrics()
-	rt, err := NewRoutingTable(ctx, 10, ConvertPeerID(local), time.Hour, m, PeerValidationFnc(PeerAlwaysValidFnc))
+	rt, err := NewRoutingTable(10, ConvertPeerID(local), time.Hour, m, PeerValidationFnc(PeerAlwaysValidFnc))
 	require.NoError(t, err)
 
 	// generate size + 1 peers to saturate a bucket
@@ -355,11 +345,10 @@ func TestTableEldestPreferred(t *testing.T) {
 
 func TestTableFindMultiple(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
 	local := test.RandPeerIDFatal(t)
 	m := pstore.NewMetrics()
-	rt, err := NewRoutingTable(ctx, 20, ConvertPeerID(local), time.Hour, m, PeerValidationFnc(PeerAlwaysValidFnc))
+	rt, err := NewRoutingTable(20, ConvertPeerID(local), time.Hour, m, PeerValidationFnc(PeerAlwaysValidFnc))
 	require.NoError(t, err)
 
 	peers := make([]peer.ID, 100)
@@ -389,13 +378,12 @@ func assertSortedPeerIdsEqual(t *testing.T, a, b []peer.ID) {
 
 func TestTableFindMultipleBuckets(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
 	local := test.RandPeerIDFatal(t)
 	localID := ConvertPeerID(local)
 	m := pstore.NewMetrics()
 
-	rt, err := NewRoutingTable(ctx, 5, localID, time.Hour, m, PeerValidationFnc(PeerAlwaysValidFnc))
+	rt, err := NewRoutingTable(5, localID, time.Hour, m, PeerValidationFnc(PeerAlwaysValidFnc))
 	require.NoError(t, err)
 
 	peers := make([]peer.ID, 100)
@@ -506,11 +494,10 @@ func TestTableFindMultipleBuckets(t *testing.T) {
 // and set GOMAXPROCS above 1
 func TestTableMultithreaded(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
 	local := peer.ID("localPeer")
 	m := pstore.NewMetrics()
-	tab, err := NewRoutingTable(ctx, 20, ConvertPeerID(local), time.Hour, m, PeerValidationFnc(PeerAlwaysValidFnc))
+	tab, err := NewRoutingTable(20, ConvertPeerID(local), time.Hour, m, PeerValidationFnc(PeerAlwaysValidFnc))
 	require.NoError(t, err)
 	var peers []peer.ID
 	for i := 0; i < 500; i++ {
@@ -548,7 +535,6 @@ func TestTableMultithreaded(t *testing.T) {
 
 func TestTableCleanup(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 	local := test.RandPeerIDFatal(t)
 
 	// Generate:
@@ -591,7 +577,7 @@ func TestTableCleanup(t *testing.T) {
 	}
 
 	// create RT with a very short cleanup interval
-	rt, err := NewRoutingTable(ctx, 3, ConvertPeerID(local), time.Hour, pstore.NewMetrics(), PeerValidationFnc(f),
+	rt, err := NewRoutingTable(3, ConvertPeerID(local), time.Hour, pstore.NewMetrics(), PeerValidationFnc(f),
 		TableCleanupInterval(100*time.Millisecond))
 	require.NoError(t, err)
 
@@ -647,14 +633,16 @@ func TestTableCleanup(t *testing.T) {
 	require.Contains(t, addedCandidates, cplPeerMap[1][3])
 	require.Contains(t, addedCandidates, cplPeerMap[1][5])
 	addedCandidatesLk.Unlock()
+
+	// close RT
+	require.NoError(t, rt.Close())
 }
 
 func BenchmarkHandlePeerAlive(b *testing.B) {
-	ctx := context.Background()
 	b.StopTimer()
 	local := ConvertKey("localKey")
 	m := pstore.NewMetrics()
-	tab, err := NewRoutingTable(ctx, 20, local, time.Hour, m, PeerValidationFnc(PeerAlwaysValidFnc))
+	tab, err := NewRoutingTable(20, local, time.Hour, m, PeerValidationFnc(PeerAlwaysValidFnc))
 	require.NoError(b, err)
 
 	var peers []peer.ID
@@ -669,11 +657,10 @@ func BenchmarkHandlePeerAlive(b *testing.B) {
 }
 
 func BenchmarkFinds(b *testing.B) {
-	ctx := context.Background()
 	b.StopTimer()
 	local := ConvertKey("localKey")
 	m := pstore.NewMetrics()
-	tab, err := NewRoutingTable(ctx, 20, local, time.Hour, m, PeerValidationFnc(PeerAlwaysValidFnc))
+	tab, err := NewRoutingTable(20, local, time.Hour, m, PeerValidationFnc(PeerAlwaysValidFnc))
 	require.NoError(b, err)
 
 	var peers []peer.ID


### PR DESCRIPTION
@raulk @Stebalien @aschmahmann @dirkmc 

For https://github.com/libp2p/go-libp2p-kad-dht/issues/283

**1.** Address management is not a part of this PR & will be next.
**2.** DHT changes will be made once this goes in.
**3.** IMO, moving the RT inside `go-libp2p-kad-dht` is a bigger refactoring that will involve multiple discussions and should be done as a separate stream of work.