### PR TITLE
Cache the XOR DHT Id for a peerID

### DIFF
--- a/sorting.go
+++ b/sorting.go
@@ -28,17 +28,17 @@ func (pds *peerDistanceSorter) Less(a, b int) bool {
 }
 
 // Append the peer.ID to the sorter's slice. It may no longer be sorted.
-func (pds *peerDistanceSorter) appendPeer(p peer.ID) {
+func (pds *peerDistanceSorter) appendPeer(p peer.ID, pDhtId ID) {
 	pds.peers = append(pds.peers, peerDistance{
 		p:        p,
-		distance: xor(pds.target, ConvertPeerID(p)),
+		distance: xor(pds.target, pDhtId),
 	})
 }
 
 // Append the peer.ID values in the list to the sorter's slice. It may no longer be sorted.
 func (pds *peerDistanceSorter) appendPeersFromList(l *list.List) {
 	for e := l.Front(); e != nil; e = e.Next() {
-		pds.appendPeer(e.Value.(*PeerInfo).Id)
+		pds.appendPeer(e.Value.(*peerInfo).Id, e.Value.(*peerInfo).dhtId)
 	}
 }
 
@@ -53,7 +53,7 @@ func SortClosestPeers(peers []peer.ID, target ID) []peer.ID {
 		target: target,
 	}
 	for _, p := range peers {
-		sorter.appendPeer(p)
+		sorter.appendPeer(p, ConvertPeerID(p))
 	}
 	sorter.sort()
 	out := make([]peer.ID, 0, sorter.Len())

--- a/table.go
+++ b/table.go
@@ -129,7 +129,7 @@ func (rt *RoutingTable) addPeer(p peer.ID, queryPeer bool) (bool, error) {
 
 	// We have enough space in the bucket (whether spawned or grouped).
 	if bucket.len() < rt.bucketsize {
-		bucket.pushFront(&PeerInfo{p, lastSuccessfulOutboundQuery})
+		bucket.pushFront(&peerInfo{p, lastSuccessfulOutboundQuery, ConvertPeerID(p)})
 		rt.PeerAdded(p)
 		return true, nil
 	}
@@ -143,7 +143,7 @@ func (rt *RoutingTable) addPeer(p peer.ID, queryPeer bool) (bool, error) {
 
 		// push the peer only if the bucket isn't overflowing after slitting
 		if bucket.len() < rt.bucketsize {
-			bucket.pushFront(&PeerInfo{p, lastSuccessfulOutboundQuery})
+			bucket.pushFront(&peerInfo{p, lastSuccessfulOutboundQuery, ConvertPeerID(p)})
 			rt.PeerAdded(p)
 			return true, nil
 		}
@@ -156,7 +156,7 @@ func (rt *RoutingTable) addPeer(p peer.ID, queryPeer bool) (bool, error) {
 		if float64(time.Since(pc.lastSuccessfulOutboundQuery)) > rt.maxLastSuccessfulOutboundThreshold {
 			// let's evict it and add the new peer
 			if bucket.remove(pc.Id) {
-				bucket.pushFront(&PeerInfo{p, lastSuccessfulOutboundQuery})
+				bucket.pushFront(&peerInfo{p, lastSuccessfulOutboundQuery, ConvertPeerID(p)})
 				rt.PeerAdded(p)
 				return true, nil
 			}
@@ -334,7 +334,7 @@ func (rt *RoutingTable) Print() {
 		fmt.Printf("\tbucket: %d\n", i)
 
 		for e := b.list.Front(); e != nil; e = e.Next() {
-			p := e.Value.(*PeerInfo).Id
+			p := e.Value.(*peerInfo).Id
 			fmt.Printf("\t\t- %s %s\n", p.Pretty(), rt.metrics.LatencyEWMA(p).String())
 		}
 	}

--- a/table_test.go
+++ b/table_test.go
@@ -33,7 +33,7 @@ func TestBucket(t *testing.T) {
 	peers := make([]peer.ID, 100)
 	for i := 0; i < 100; i++ {
 		peers[i] = test.RandPeerIDFatal(t)
-		b.pushFront(&PeerInfo{peers[i], testTime1})
+		b.pushFront(&peerInfo{peers[i], testTime1, ConvertPeerID(peers[i])})
 	}
 
 	local := test.RandPeerIDFatal(t)
@@ -46,6 +46,7 @@ func TestBucket(t *testing.T) {
 	p := b.getPeer(peers[i])
 	require.NotNil(t, p)
 	require.Equal(t, peers[i], p.Id)
+	require.Equal(t, ConvertPeerID(peers[i]), p.dhtId)
 	require.EqualValues(t, testTime1, p.lastSuccessfulOutboundQuery)
 
 	// mark as missing
@@ -58,7 +59,7 @@ func TestBucket(t *testing.T) {
 	spl := b.split(0, ConvertPeerID(local))
 	llist := b.list
 	for e := llist.Front(); e != nil; e = e.Next() {
-		p := ConvertPeerID(e.Value.(*PeerInfo).Id)
+		p := ConvertPeerID(e.Value.(*peerInfo).Id)
 		cpl := CommonPrefixLen(p, localID)
 		if cpl > 0 {
 			t.Fatalf("split failed. found id with cpl > 0 in 0 bucket")
@@ -67,7 +68,7 @@ func TestBucket(t *testing.T) {
 
 	rlist := spl.list
 	for e := rlist.Front(); e != nil; e = e.Next() {
-		p := ConvertPeerID(e.Value.(*PeerInfo).Id)
+		p := ConvertPeerID(e.Value.(*peerInfo).Id)
 		cpl := CommonPrefixLen(p, localID)
 		if cpl == 0 {
 			t.Fatalf("split failed. found id with cpl == 0 in non 0 bucket")


### PR DESCRIPTION
@Stebalien @aschmahmann 

For https://github.com/libp2p/go-libp2p/issues/812 AND https://github.com/libp2p/go-libp2p-kbucket/pull/64.

Saves us from having to do repeated SHA's.