### PR TITLE
Add LastUsefulAt and LastSuccessfulQueryAt for each peer

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -12,9 +12,14 @@ import (
 // PeerInfo holds all related information for a peer in the K-Bucket.
 type PeerInfo struct {
 	Id peer.ID
-	// LastSuccessfulOutboundQuery is the time instant when we last made a successful
-	// outbound query to this peer
-	LastSuccessfulOutboundQuery time.Time
+
+	// LastUsefulAt is the time instant at which the peer was last "useful" to us.
+	// Please see the DHT docs for the definition of usefulness.
+	LastUsefulAt time.Time
+
+	// LastSuccessfulOutboundQueryAt is the time instant at which we last got a
+	// successful query response from the peer.
+	LastSuccessfulOutboundQueryAt time.Time
 
 	// Id of the peer in the DHT XOR keyspace
 	dhtId ID

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/libp2p/go-libp2p-kbucket
 require (
 	github.com/ipfs/go-ipfs-util v0.0.1
 	github.com/ipfs/go-log v1.0.3
-	github.com/jbenet/goprocess v0.1.3
+	github.com/jbenet/goprocess v0.1.4
 	github.com/libp2p/go-libp2p-core v0.5.1
 	github.com/libp2p/go-libp2p-peerstore v0.2.2
 	github.com/minio/sha256-simd v0.1.1

--- a/table_test.go
+++ b/table_test.go
@@ -226,6 +226,27 @@ func TestUpdateLastSuccessfulOutboundQueryAt(t *testing.T) {
 	rt.tabLock.Unlock()
 }
 
+func TestUpdateLastUsefulAt(t *testing.T) {
+	local := test.RandPeerIDFatal(t)
+	m := pstore.NewMetrics()
+	rt, err := NewRoutingTable(10, ConvertPeerID(local), time.Hour, m, NoOpThreshold)
+	require.NoError(t, err)
+
+	p := test.RandPeerIDFatal(t)
+	b, err := rt.TryAddPeer(p, true)
+	require.True(t, b)
+	require.NoError(t, err)
+
+	// increment and assert
+	t2 := time.Now().Add(1 * time.Hour)
+	rt.UpdateLastUsefulAt(p, t2)
+	rt.tabLock.Lock()
+	pi := rt.buckets[0].getPeer(p)
+	require.NotNil(t, pi)
+	require.EqualValues(t, t2, pi.LastUsefulAt)
+	rt.tabLock.Unlock()
+}
+
 func TestTryAddPeer(t *testing.T) {
 	minThreshold := float64(24 * 1 * time.Hour)
 	t.Parallel()

--- a/table_test.go
+++ b/table_test.go
@@ -27,13 +27,14 @@ func TestPrint(t *testing.T) {
 func TestBucket(t *testing.T) {
 	t.Parallel()
 	testTime1 := time.Now()
+	testTime2 := time.Now().AddDate(1, 0, 0)
 
 	b := newBucket()
 
 	peers := make([]peer.ID, 100)
 	for i := 0; i < 100; i++ {
 		peers[i] = test.RandPeerIDFatal(t)
-		b.pushFront(&PeerInfo{peers[i], testTime1, ConvertPeerID(peers[i])})
+		b.pushFront(&PeerInfo{peers[i], testTime1, testTime2, ConvertPeerID(peers[i])})
 	}
 
 	local := test.RandPeerIDFatal(t)
@@ -47,14 +48,17 @@ func TestBucket(t *testing.T) {
 	require.NotNil(t, p)
 	require.Equal(t, peers[i], p.Id)
 	require.Equal(t, ConvertPeerID(peers[i]), p.dhtId)
-	require.EqualValues(t, testTime1, p.LastSuccessfulOutboundQuery)
+	require.EqualValues(t, testTime1, p.LastUsefulAt)
+	require.EqualValues(t, testTime2, p.LastSuccessfulOutboundQueryAt)
 
-	// mark as missing
 	t2 := time.Now().Add(1 * time.Hour)
-	p.LastSuccessfulOutboundQuery = t2
+	t3 := t2.Add(1 * time.Hour)
+	p.LastSuccessfulOutboundQueryAt = t2
+	p.LastUsefulAt = t3
 	p = b.getPeer(peers[i])
 	require.NotNil(t, p)
-	require.EqualValues(t, t2, p.LastSuccessfulOutboundQuery)
+	require.EqualValues(t, t2, p.LastSuccessfulOutboundQueryAt)
+	require.EqualValues(t, t3, p.LastUsefulAt)
 
 	spl := b.split(0, ConvertPeerID(local))
 	llist := b.list
@@ -201,7 +205,7 @@ func TestTableFind(t *testing.T) {
 	}
 }
 
-func TestUpdateLastSuccessfulOutboundQuery(t *testing.T) {
+func TestUpdateLastSuccessfulOutboundQueryAt(t *testing.T) {
 	local := test.RandPeerIDFatal(t)
 	m := pstore.NewMetrics()
 	rt, err := NewRoutingTable(10, ConvertPeerID(local), time.Hour, m, NoOpThreshold)
@@ -214,11 +218,11 @@ func TestUpdateLastSuccessfulOutboundQuery(t *testing.T) {
 
 	// increment and assert
 	t2 := time.Now().Add(1 * time.Hour)
-	rt.UpdateLastSuccessfulOutboundQuery(p, t2)
+	rt.UpdateLastSuccessfulOutboundQueryAt(p, t2)
 	rt.tabLock.Lock()
 	pi := rt.buckets[0].getPeer(p)
 	require.NotNil(t, pi)
-	require.EqualValues(t, t2, pi.LastSuccessfulOutboundQuery)
+	require.EqualValues(t, t2, pi.LastSuccessfulOutboundQueryAt)
 	rt.tabLock.Unlock()
 }
 
@@ -257,9 +261,9 @@ func TestTryAddPeer(t *testing.T) {
 	require.True(t, b)
 	require.Equal(t, p4, rt.Find(p4))
 
-	// adding a peer with cpl 0 works if an existing peer has LastSuccessfulOutboundQuery above the max threshold
+	// adding a peer with cpl 0 works if an existing peer has LastUsefulAt above the max threshold
 	// because that existing peer will get replaced
-	require.True(t, rt.UpdateLastSuccessfulOutboundQuery(p2, time.Now().AddDate(0, 0, -2)))
+	require.True(t, rt.UpdateLastUsefulAt(p2, time.Now().AddDate(0, 0, -2)))
 	b, err = rt.TryAddPeer(p3, true)
 	require.NoError(t, err)
 	require.True(t, b)
@@ -271,7 +275,7 @@ func TestTryAddPeer(t *testing.T) {
 	// however adding peer fails if below threshold
 	p5, err := rt.GenRandPeerID(0)
 	require.NoError(t, err)
-	require.True(t, rt.UpdateLastSuccessfulOutboundQuery(p1, time.Now()))
+	require.True(t, rt.UpdateLastUsefulAt(p1, time.Now()))
 	b, err = rt.TryAddPeer(p5, true)
 	require.Error(t, err)
 	require.False(t, b)
@@ -285,7 +289,7 @@ func TestTryAddPeer(t *testing.T) {
 	rt.tabLock.Lock()
 	pi := rt.buckets[rt.bucketIdForPeer(p6)].getPeer(p6)
 	require.NotNil(t, p6)
-	require.True(t, pi.LastSuccessfulOutboundQuery.IsZero())
+	require.True(t, pi.LastUsefulAt.IsZero())
 	rt.tabLock.Unlock()
 
 }
@@ -425,9 +429,9 @@ func TestGetPeerInfos(t *testing.T) {
 	}
 
 	require.Equal(t, p1, ms[p1].Id)
-	require.True(t, ms[p1].LastSuccessfulOutboundQuery.IsZero())
+	require.True(t, ms[p1].LastUsefulAt.IsZero())
 	require.Equal(t, p2, ms[p2].Id)
-	require.False(t, ms[p2].LastSuccessfulOutboundQuery.IsZero())
+	require.False(t, ms[p2].LastUsefulAt.IsZero())
 }
 
 func BenchmarkAddPeer(b *testing.B) {


### PR DESCRIPTION
`LastUsefulAt` helps evict peers that aren't being useful.
`LastSuccessfulQueryAt` decides which peers we ping periodically to check liveliness.