### PR TITLE
Fixes #89 - Use functional opts to create Routing Table

### DIFF
--- a/table.go
+++ b/table.go
@@ -60,24 +60,16 @@ type RoutingTable struct {
 }
 
 // NewRoutingTable creates a new routing table with a given bucketsize, local ID, and latency tolerance.
-func NewRoutingTable(bucketsize int, localID ID, latency time.Duration, m peerstore.Metrics, usefulnessGracePeriod time.Duration,
-	df *peerdiversity.Filter) (*RoutingTable, error) {
+func NewRoutingTable(opts ...func(*RoutingTable) *RoutingTable) (*RoutingTable, error) {
 	rt := &RoutingTable{
-		buckets:    []*bucket{newBucket()},
-		bucketsize: bucketsize,
-		local:      localID,
-
-		maxLatency: latency,
-		metrics:    m,
-
+		buckets: []*bucket{newBucket()},
 		cplRefreshedAt: make(map[uint]time.Time),
-
 		PeerRemoved: func(peer.ID) {},
-		PeerAdded:   func(peer.ID) {},
+		PeerAdded: func(peer.ID) {},
+	}
 
-		usefulnessGracePeriod: usefulnessGracePeriod,
-
-		df: df,
+	for _, opt := range opts {
+		rt = opt(rt)
 	}
 
 	rt.ctx, rt.ctxCancel = context.WithCancel(context.Background())

--- a/table_refresh_test.go
+++ b/table_refresh_test.go
@@ -7,17 +7,14 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/test"
 
-	pstore "github.com/libp2p/go-libp2p-peerstore"
-
 	"github.com/stretchr/testify/require"
 )
 
 func TestGenRandPeerID(t *testing.T) {
 	t.Parallel()
+	local := ConvertPeerID(test.RandPeerIDFatal(t))
 
-	local := test.RandPeerIDFatal(t)
-	m := pstore.NewMetrics()
-	rt, err := NewRoutingTable(1, ConvertPeerID(local), time.Hour, m, NoOpThreshold, nil)
+	rt, err := NewRoutingTable(baseTestOpts(1, local))
 	require.NoError(t, err)
 
 	// generate above maxCplForRefresh fails
@@ -44,8 +41,8 @@ func TestRefreshAndGetTrackedCpls(t *testing.T) {
 	)
 
 	local := test.RandPeerIDFatal(t)
-	m := pstore.NewMetrics()
-	rt, err := NewRoutingTable(2, ConvertPeerID(local), time.Hour, m, NoOpThreshold, nil)
+
+	rt, err := NewRoutingTable(baseTestOpts(2, ConvertPeerID(local)))
 	require.NoError(t, err)
 
 	// fetch cpl's


### PR DESCRIPTION
@aarshkshah1992 was this what you had in mind?

Any thoughts on backwards compatibility? Otherwise changes will be needed in go-libp2p-kad-dht and maybe other places.