### PR TITLE
UsefulPeer function

### DIFF
--- a/table.go
+++ b/table.go
@@ -128,13 +128,13 @@ func (rt *RoutingTable) UsefulPeer(p peer.ID) bool {
 		return true
 	}
 
-	// find and returns a replaceable peer (if any)
-	replaceablePeer := bucket.min(func(p1 *PeerInfo, p2 *PeerInfo) bool {
-		return p1.replaceable
-	})
-	if replaceablePeer != nil && replaceablePeer.replaceable {
-		// at least 1 peer is replaceable
-		return true
+	// bucket is full, check if it contains replaceable peers
+	for e := bucket.list.Front(); e != nil; e = e.Next() {
+		peer := e.Value.(*PeerInfo)
+		if peer.replaceable {
+			// at least 1 peer is replaceable
+			return true
+		}
 	}
 
 	// the last bucket potentially contains peer ids with different CPL,

--- a/table_test.go
+++ b/table_test.go
@@ -188,7 +188,6 @@ func TestUsefulPeer(t *testing.T) {
 	p, _ = rt.GenRandPeerID(1)
 	require.False(t, rt.UsefulPeer(p))
 	rt.TryAddPeer(p, true, false)
-
 }
 
 func TestEmptyBucketCollapse(t *testing.T) {

--- a/table_test.go
+++ b/table_test.go
@@ -126,6 +126,71 @@ func TestNPeersForCpl(t *testing.T) {
 	require.Equal(t, 2, rt.NPeersForCpl(0))
 }
 
+func TestUsefulPeer(t *testing.T) {
+	t.Parallel()
+	local := test.RandPeerIDFatal(t)
+	m := pstore.NewMetrics()
+	rt, err := NewRoutingTable(2, ConvertPeerID(local), time.Hour, m, NoOpThreshold, nil)
+	require.NoError(t, err)
+
+	// add first peer to bucket 0
+	p, _ := rt.GenRandPeerID(0)
+	require.True(t, rt.UsefulPeer(p))
+	rt.TryAddPeer(p, true, false)
+
+	// add second peer to bucket 0
+	p, _ = rt.GenRandPeerID(0)
+	require.True(t, rt.UsefulPeer(p))
+	rt.TryAddPeer(p, true, false)
+
+	// bucket 0 (also last bucket) full with non replaceable peers
+	p, _ = rt.GenRandPeerID(0)
+	require.False(t, rt.UsefulPeer(p))
+
+	// bucket 0 is full, unfolding it
+	// add first peer to bucket 1
+	p, _ = rt.GenRandPeerID(1)
+	require.True(t, rt.UsefulPeer(p))
+	rt.TryAddPeer(p, true, false)
+
+	// add second peer to bucket 1
+	// cpl is 2, but bucket 1 is last bucket
+	p, _ = rt.GenRandPeerID(2)
+	require.True(t, rt.UsefulPeer(p))
+	rt.TryAddPeer(p, true, false)
+
+	// unfolding bucket 1
+	// adding second peer to bucket 2
+	p, _ = rt.GenRandPeerID(2)
+	require.True(t, rt.UsefulPeer(p))
+	rt.TryAddPeer(p, true, false)
+
+	// adding replaceable peer to bucket 1
+	// bucket 1 size: 1 -> 2
+	p, _ = rt.GenRandPeerID(1)
+	require.True(t, rt.UsefulPeer(p))
+	rt.TryAddPeer(p, true, true)
+
+	// adding replaceable peer to bucket 1
+	// bucket 1 size: 2 -> 2
+	p, _ = rt.GenRandPeerID(1)
+	require.True(t, rt.UsefulPeer(p))
+	rt.TryAddPeer(p, true, true)
+
+	// adding non replaceable peer to bucket 1
+	// bucket 1 size: 2 -> 2
+	p, _ = rt.GenRandPeerID(1)
+	require.True(t, rt.UsefulPeer(p))
+	rt.TryAddPeer(p, true, false)
+
+	// adding non replaceable peer to bucket 1
+	// bucket 1 size: 2 -> 2
+	p, _ = rt.GenRandPeerID(1)
+	require.False(t, rt.UsefulPeer(p))
+	rt.TryAddPeer(p, true, false)
+
+}
+
 func TestEmptyBucketCollapse(t *testing.T) {
 	t.Parallel()
 	local := test.RandPeerIDFatal(t)


### PR DESCRIPTION
UsefulPeer verifies whether a given peer.ID would be a good fit for the routing table. It returns true if the bucket corresponding to peer.ID isn't full, if it contains replaceable peers or if it is the last bucket and adding a peer would unfold it.

This function is necessary for [go-libp2p-kad-dht](https://github.com/libp2p/go-libp2p-kad-dht), as remote DHT servers are queried before they are added to the DHT. We don't want to query peers whose ID belong to a full bucket anyway. This function helps preventing querying useless peers.

References: https://github.com/libp2p/go-libp2p-kad-dht/pull/820