### PR TITLE
GenRandomKey function

### DIFF
--- a/table_refresh_test.go
+++ b/table_refresh_test.go
@@ -34,6 +34,86 @@ func TestGenRandPeerID(t *testing.T) {
 	}
 }
 
+func TestGenRandomKey(t *testing.T) {
+	// test can be run in parallel
+	t.Parallel()
+
+	// run multiple occurences to make sure the test wasn't just lucky
+	for i := 0; i < 100; i++ {
+		// generate routing table with random local peer ID
+		local := test.RandPeerIDFatal(t)
+		m := pstore.NewMetrics()
+		rt, err := NewRoutingTable(1, ConvertPeerID(local), time.Hour, m, NoOpThreshold, nil)
+		require.NoError(t, err)
+
+		// GenRandomKey fails for cpl >= 256
+		_, err = rt.GenRandomKey(256)
+		require.Error(t, err)
+		_, err = rt.GenRandomKey(300)
+		require.Error(t, err)
+
+		// bitwise comparison legend:
+		// O for same bit, X for different bit, ? for don't care
+
+		// we compare the returned generated key with the local key
+		// for CPL = X, the first X bits should be the same, bit X+1 should be
+		// different, and the rest should be random / don't care
+
+		// cpl = 0 should return a different first bit
+		// X??????? ???...
+		key0, err := rt.GenRandomKey(0)
+		require.NoError(t, err)
+		// most significant bit should be different
+		require.NotEqual(t, key0[0]>>7, rt.local[0]>>7)
+
+		// cpl = 1 should return a different second bit
+		// OX?????? ???...
+		key1, err := rt.GenRandomKey(1)
+		require.NoError(t, err)
+		// MSB should be equal, as cpl = 1
+		require.Equal(t, key1[0]>>7, rt.local[0]>>7)
+		// 2nd MSB should be different
+		require.NotEqual(t, (key1[0]<<1)>>6, (rt.local[0]<<1)>>6)
+
+		// cpl = 2 should return a different third bit
+		// OOX????? ???...
+		key2, err := rt.GenRandomKey(2)
+		require.NoError(t, err)
+		// 2 MSB should be equal, as cpl = 2
+		require.Equal(t, key2[0]>>6, rt.local[0]>>6)
+		// 3rd MSB should be different
+		require.NotEqual(t, (key2[0]<<2)>>5, (rt.local[0]<<2)>>5)
+
+		// cpl = 7 should return a different eighth bit
+		// OOOOOOOX ???...
+		key7, err := rt.GenRandomKey(7)
+		require.NoError(t, err)
+		// 7 MSB should be equal, as cpl = 7
+		require.Equal(t, key7[0]>>1, rt.local[0]>>1)
+		// 8th MSB should be different
+		require.NotEqual(t, key7[0]<<7, rt.local[0]<<7)
+
+		// cpl = 8 should return a different ninth bit
+		// OOOOOOOO X???...
+		key8, err := rt.GenRandomKey(8)
+		require.NoError(t, err)
+		// 8 MSB should be equal, as cpl = 8
+		require.Equal(t, key8[0], rt.local[0])
+		// 9th MSB should be different
+		require.NotEqual(t, key8[1]>>7, rt.local[1]>>7)
+
+		// cpl = 53 should return a different 54th bit
+		// OOOOOOOO OOOOOOOO OOOOOOOO OOOOOOOO OOOOOOOO OOOOOOOO OOOOOX?? ???...
+		key53, err := rt.GenRandomKey(53)
+		require.NoError(t, err)
+		// 53 MSB should be equal, as cpl = 53
+		require.Equal(t, key53[:6], rt.local[:6])
+		require.Equal(t, key53[6]>>3, rt.local[6]>>3)
+		// 54th MSB should be different
+		require.NotEqual(t, (key53[6]<<5)>>7, (rt.local[6]<<5)>>7)
+	}
+}
+
 func TestRefreshAndGetTrackedCpls(t *testing.T) {
 	t.Parallel()
 

--- a/util.go
+++ b/util.go
@@ -15,6 +15,9 @@ import (
 // behaviour
 var ErrLookupFailure = errors.New("failed to find any peer in table")
 
+// Keysize is the size of the Kademlia ID in bytes
+const Keysize = 32
+
 // ID for IpfsDHT is in the XORKeySpace
 //
 // The type dht.ID signifies that its contents have been hashed from either a


### PR DESCRIPTION
Add a `GenRandomKey(targetCpl)` function similar to `GenRandPeerID(targetCpl)` but not requiring the list of precomputed hash preimages.

This function generates a random Kademlia key (32 bytes), whose first `targetCpl` bits are shared with the local key of the routing table.

It is useful as we get to replace string oriented requests with byte oriented requests in [go-libp2p-kad-dht)](https://github.com/libp2p/go-libp2p-kad-dht). It is a prerequisite for the Double Hash DHT implementation.