### PR TITLE
fixed kbucket bug :)

### DIFF
--- a/table.go
+++ b/table.go
@@ -222,6 +222,9 @@ func (rt *RoutingTable) addPeer(p peer.ID, queryPeer bool, isReplaceable bool) (
 	if replaceablePeer != nil && replaceablePeer.replaceable {
 		// let's evict it and add the new peer
 		if rt.removePeer(replaceablePeer.Id) {
+			// bug fix :)
+			bucketID = rt.bucketIdForPeer(p)
+			bucket = rt.buckets[bucketID]
 			bucket.pushFront(&PeerInfo{
 				Id:                            p,
 				LastUsefulAt:                  lastUsefulAt,

--- a/table.go
+++ b/table.go
@@ -220,22 +220,24 @@ func (rt *RoutingTable) addPeer(p peer.ID, queryPeer bool, isReplaceable bool) (
 	})
 
 	if replaceablePeer != nil && replaceablePeer.replaceable {
-		// let's evict it and add the new peer
-		if rt.removePeer(replaceablePeer.Id) {
-			// bug fix :)
-			bucketID = rt.bucketIdForPeer(p)
-			bucket = rt.buckets[bucketID]
-			bucket.pushFront(&PeerInfo{
-				Id:                            p,
-				LastUsefulAt:                  lastUsefulAt,
-				LastSuccessfulOutboundQueryAt: now,
-				AddedAt:                       now,
-				dhtId:                         ConvertPeerID(p),
-				replaceable:                   isReplaceable,
-			})
-			rt.PeerAdded(p)
-			return true, nil
-		}
+		// we found a replaceable peer, let's replace it with the new peer.
+
+		// add new peer to the bucket. needs to happen before we remove the replaceable peer
+		// as if the bucket size is 1, we will end up removing the only peer, and deleting
+		// the bucket.
+		bucket.pushFront(&PeerInfo{
+			Id:                            p,
+			LastUsefulAt:                  lastUsefulAt,
+			LastSuccessfulOutboundQueryAt: now,
+			AddedAt:                       now,
+			dhtId:                         ConvertPeerID(p),
+			replaceable:                   isReplaceable,
+		})
+		rt.PeerAdded(p)
+
+		// remove the replaceable peer
+		rt.removePeer(replaceablePeer.Id)
+		return true, nil
 	}
 
 	// we weren't able to find place for the peer, remove it from the filter state.

--- a/table_test.go
+++ b/table_test.go
@@ -447,6 +447,24 @@ func TestTryAddPeer(t *testing.T) {
 
 }
 
+func TestReplacePeerWithBucketSize1(t *testing.T) {
+	localID := test.RandPeerIDFatal(t)
+	rt, err := NewRoutingTable(1, ConvertPeerID(localID), time.Hour, pstore.NewMetrics(), NoOpThreshold, nil)
+	require.NoError(t, err)
+	p1, _ := rt.GenRandPeerID(1) // for any targetCpl > 0
+	p2, _ := rt.GenRandPeerID(1)
+
+	rt.TryAddPeer(p1, true, true)
+	success, err := rt.TryAddPeer(p2, true, true)
+
+	require.NoError(t, err)
+	require.True(t, success)
+
+	require.Equal(t, peer.ID(""), rt.Find(p1))
+	require.Equal(t, p2, rt.Find(p2))
+	require.Equal(t, rt.Size(), 1)
+}
+
 func TestMarkAllPeersIrreplaceable(t *testing.T) {
 	t.Parallel()
 
@@ -766,22 +784,4 @@ func BenchmarkFinds(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		tab.Find(peers[i])
 	}
-}
-
-
-
-func TestBugFinder(t *testing.T) {
-	localID := test.RandPeerIDFatal(t)
-	rt, err := NewRoutingTable(1, ConvertPeerID(localID), time.Hour, pstore.NewMetrics(), NoOpThreshold, nil)
-	require.NoError(t, err)
-	p1, _ := rt.GenRandPeerID(1) // for any targetCtl > 0
-	p2, _ := rt.GenRandPeerID(1)
-
-	rt.TryAddPeer(p1, true, true)
-	rt.TryAddPeer(p2, true, true)
-
-	require.Equal(t, rt.Find(p1), peer.ID(""))
-	require.Equal(t, rt.Find(p2), p2)
-	require.Equal(t, rt.Size(), 1)
-
 }

--- a/table_test.go
+++ b/table_test.go
@@ -767,3 +767,21 @@ func BenchmarkFinds(b *testing.B) {
 		tab.Find(peers[i])
 	}
 }
+
+
+
+func TestBugFinder(t *testing.T) {
+	localID := test.RandPeerIDFatal(t)
+	rt, err := NewRoutingTable(1, ConvertPeerID(localID), time.Hour, pstore.NewMetrics(), NoOpThreshold, nil)
+	require.NoError(t, err)
+	p1, _ := rt.GenRandPeerID(1) // for any targetCtl > 0
+	p2, _ := rt.GenRandPeerID(1)
+
+	rt.TryAddPeer(p1, true, true)
+	rt.TryAddPeer(p2, true, true)
+
+	require.Equal(t, rt.Find(p1), peer.ID(""))
+	require.Equal(t, rt.Find(p2), p2)
+	require.Equal(t, rt.Size(), 1)
+
+}


### PR DESCRIPTION
I just added a test called TestBugFinder which fails because when adding a new peer to a bucket in which another peer will be evicted to make space for the new one (having the bucketsize = 1), the code just doesn't take into account that the bucket where the new peer info is going to be added may be deleted from the routing table. 
I just added lines that take care of it.  I know the test is very specific and that the probability of the bucketsize being equals to 1 is very little, but when someone uses the code she/he usually assumes it will work just fine.