### PR TITLE
fix: fix abba bug in UsefullNewPeer

### DIFF
--- a/table.go
+++ b/table.go
@@ -120,7 +120,7 @@ func (rt *RoutingTable) UsefulNewPeer(p peer.ID) bool {
 	rt.tabLock.RLock()
 	defer rt.tabLock.RUnlock()
 
-	if rt.Find(p) != "" {
+	if rt.find(p) != "" {
 		// peer already exists in the routing table, so it isn't useful
 		return false
 	}
@@ -412,12 +412,21 @@ func (rt *RoutingTable) nextBucket() {
 }
 
 // Find a specific peer by ID or return nil
-func (rt *RoutingTable) Find(id peer.ID) peer.ID {
-	srch := rt.NearestPeers(ConvertPeerID(id), 1)
-	if len(srch) == 0 || srch[0] != id {
+func (rt *RoutingTable) Find(p peer.ID) peer.ID {
+	rt.tabLock.RLock()
+	defer rt.tabLock.RUnlock()
+
+	return rt.find(p)
+}
+
+// caller is responsible for calling
+func (rt *RoutingTable) find(p peer.ID) peer.ID {
+	pi := rt.buckets[rt.bucketIdForPeer(p)].getPeer(p)
+	if pi == nil {
 		return ""
 	}
-	return srch[0]
+
+	return p
 }
 
 // NearestPeer returns a single peer that is nearest to the given ID

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.6.2"
+  "version": "v0.6.3"
 }


### PR DESCRIPTION
This fixes a deadlock the issue is that this pattern could happen because .Find inside UsefullNewPeer would aquire the same RLock:
- UsefullNewPeer takes tablock.RLock
- Something else tries to take tablock.Lock (waits)
- UsefullNewPeer calls Find calls NearestPeer call NearestPeers which trie to take tablock.RLock again, here RLock waits because the rwmutex is starving, it will wait for the Something else to aqcuire the Lock first else a constant flow of reader would block the RWMutex forever.