### PR TITLE
feat: add log printing when peer added and removed table

### DIFF
--- a/table.go
+++ b/table.go
@@ -72,8 +72,12 @@ func NewRoutingTable(bucketsize int, localID ID, latency time.Duration, m peerst
 
 		cplRefreshedAt: make(map[uint]time.Time),
 
-		PeerRemoved: func(peer.ID) {},
-		PeerAdded:   func(peer.ID) {},
+		PeerRemoved: func(p peer.ID) {
+			log.Debugw("peer removed", "peer", p)
+		},
+		PeerAdded: func(p peer.ID) {
+			log.Debugw("peer added", "peer", p)
+		},
 
 		usefulnessGracePeriod: usefulnessGracePeriod,
 


### PR DESCRIPTION
As of now, I don't think there is a major log in Kademlia that *certainly* can determine that a peer has been added.

The login `'msg': 'peer found'` output, which is called prior to the commit, is only an possibility to add for the peer, and the fact that `'rt.PeerAdd()'`, which is actually called when a peer is added, is an empty function makes it difficult to measure the performance of Kademlia.

```go
		PeerRemoved: func(p peer.ID) {
			log.Debugw("peer removed", "peer", p)
		},
		PeerAdded: func(p peer.ID) {
			log.Debugw("peer added", "peer", p)
		},
```

Thus, a simple log-add syntax was added.