### PR TITLE
peerdiversity: export IPGroupKey

### DIFF
--- a/peerdiversity/filter.go
+++ b/peerdiversity/filter.go
@@ -161,7 +161,7 @@ func (f *Filter) TryAdd(p peer.ID) bool {
 		}
 
 		// reject the peer if we can't determine a grouping for one of it's address.
-		key := f.ipGroupKey(ip)
+		key := f.IPGroupKey(ip)
 		if len(key) == 0 {
 			dfLog.Errorw("group key is empty", "appKey", f.logKey, "ip", ip.String(), "peer", p)
 			return false
@@ -200,7 +200,7 @@ func (f *Filter) WhitelistPeers(peers ...peer.ID) {
 }
 
 // returns the PeerIPGroupKey to which the given IP belongs.
-func (f *Filter) ipGroupKey(ip net.IP) PeerIPGroupKey {
+func (f *Filter) IPGroupKey(ip net.IP) PeerIPGroupKey {
 	switch bz := ip.To4(); bz {
 	case nil:
 		// ipv6 Address -> get ASN

--- a/peerdiversity/filter_test.go
+++ b/peerdiversity/filter_test.go
@@ -94,11 +94,15 @@ func TestDiversityFilter(t *testing.T) {
 			mFnc: func(m *mockPeerGroupFilter) {
 				m.peerAddressFunc = func(id peer.ID) []ma.Multiaddr {
 					if id == "p1" {
-						return []ma.Multiaddr{ma.StringCast("/ip4/127.0.0.1/tcp/0"),
-							ma.StringCast("/ip4/127.0.0.1/tcp/0")}
+						return []ma.Multiaddr{
+							ma.StringCast("/ip4/127.0.0.1/tcp/0"),
+							ma.StringCast("/ip4/127.0.0.1/tcp/0"),
+						}
 					}
-					return []ma.Multiaddr{ma.StringCast("/ip4/127.0.0.1/tcp/0"),
-						ma.StringCast("/ip4/192.168.1.1/tcp/0")}
+					return []ma.Multiaddr{
+						ma.StringCast("/ip4/127.0.0.1/tcp/0"),
+						ma.StringCast("/ip4/192.168.1.1/tcp/0"),
+					}
 				}
 				m.allowFnc = func(g PeerGroupInfo) bool { return g.IPGroupKey == "127.0.0.0" }
 			},
@@ -232,18 +236,18 @@ func TestIPGroupKey(t *testing.T) {
 	// case 1 legacy /8
 	ip := net.ParseIP("17.111.0.1")
 	require.NotNil(t, ip.To4())
-	g := f.ipGroupKey(ip)
+	g := f.IPGroupKey(ip)
 	require.Equal(t, "17.0.0.0", string(g))
 
 	// case2 ip4 /16
 	ip = net.ParseIP("192.168.1.1")
 	require.NotNil(t, ip.To4())
-	g = f.ipGroupKey(ip)
+	g = f.IPGroupKey(ip)
 	require.Equal(t, "192.168.0.0", string(g))
 
 	// case3 ipv6
 	ip = net.ParseIP("2a03:2880:f003:c07:face:b00c::2")
-	g = f.ipGroupKey(ip)
+	g = f.IPGroupKey(ip)
 	require.Equal(t, strconv.FormatUint(uint64(asnutil.AsnForIPv6(ip)), 10), string(g))
 }
 


### PR DESCRIPTION
`IPGroupKey` is useful outside of the routing table's diversity filter, e.g to filter IP in DHT lookup responses.

The routing table's `DiversityFilter` must also be exposed for the `IPGroupKey` function to be used.