### PR TITLE
refactor: replace Sort interface with slices.SortFunc

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,13 @@
 
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](https://protocol.ai)
 [![](https://img.shields.io/badge/project-libp2p-yellow.svg?style=flat-square)](https://libp2p.io/)
-[![](https://img.shields.io/badge/freenode-%23libp2p-yellow.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23libp2p)
 [![Discourse posts](https://img.shields.io/discourse/https/discuss.libp2p.io/posts.svg)](https://discuss.libp2p.io)
 
 > A kbucket implementation for use as a routing table in go-libp2p-kad-dht
 
 ## Documenation
 
-See https://godoc.org/github.com/libp2p/go-libp2p-kbucket.
+See https://pkg.go.dev/github.com/libp2p/go-libp2p-kbucket
 
 ## Contribute
 
@@ -24,7 +23,3 @@ This repository falls under the libp2p [Code of Conduct](https://github.com/libp
 ## License
 
 MIT
-
----
-
-The last gx published version of this module was: 2.2.23: QmSNE1XryoCMnZCbRaj1D23k6YKCaTQ386eJciu1pAfu8M

--- a/keyspace/keyspace.go
+++ b/keyspace/keyspace.go
@@ -17,7 +17,7 @@ type Key struct {
 	Bytes []byte
 }
 
-// Cmp returns in integer that compares the two Keys.
+// Cmp returns an integer that compares the two Keys.
 func (k1 Key) Cmp(k2 Key) int {
 	if k1.Space != k2.Space {
 		panic("k1 and k2 not in same key space.")

--- a/keyspace/keyspace.go
+++ b/keyspace/keyspace.go
@@ -1,24 +1,28 @@
 package keyspace
 
 import (
-	"sort"
-
 	"math/big"
+	"slices"
 )
 
 // Key represents an identifier in a KeySpace. It holds a reference to the
 // associated KeySpace, as well references to both the Original identifier,
 // as well as the new, KeySpace Bytes one.
 type Key struct {
-
 	// Space is the KeySpace this Key is related to.
 	Space KeySpace
-
 	// Original is the original value of the identifier
 	Original []byte
-
 	// Bytes is the new value of the identifier, in the KeySpace.
 	Bytes []byte
+}
+
+// Cmp returns in integer that compares the two Keys.
+func (k1 Key) Cmp(k2 Key) int {
+	if k1.Space != k2.Space {
+		panic("k1 and k2 not in same key space.")
+	}
+	return k1.Space.Cmp(k1, k2)
 }
 
 // Equal returns whether this key is equal to another.
@@ -48,50 +52,25 @@ func (k1 Key) Distance(k2 Key) *big.Int {
 // KeySpace is an object used to do math on identifiers. Each keyspace has its
 // own properties and rules. See XorKeySpace.
 type KeySpace interface {
-
 	// Key converts an identifier into a Key in this space.
 	Key([]byte) Key
-
 	// Equal returns whether keys are equal in this key space
 	Equal(Key, Key) bool
-
 	// Distance returns the distance metric in this key space
 	Distance(Key, Key) *big.Int
-
+	// Cmp returns an integer comparing two keys.
+	Cmp(Key, Key) int
 	// Less returns whether the first key is smaller than the second.
 	Less(Key, Key) bool
-}
-
-// byDistanceToCenter is a type used to sort Keys by proximity to a center.
-type byDistanceToCenter struct {
-	Center Key
-	Keys   []Key
-}
-
-func (s byDistanceToCenter) Len() int {
-	return len(s.Keys)
-}
-
-func (s byDistanceToCenter) Swap(i, j int) {
-	s.Keys[i], s.Keys[j] = s.Keys[j], s.Keys[i]
-}
-
-func (s byDistanceToCenter) Less(i, j int) bool {
-	a := s.Center.Distance(s.Keys[i])
-	b := s.Center.Distance(s.Keys[j])
-	return a.Cmp(b) == -1
 }
 
 // SortByDistance takes a KeySpace, a center Key, and a list of Keys toSort.
 // It returns a new list, where the Keys toSort have been sorted by their
 // distance to the center Key.
 func SortByDistance(sp KeySpace, center Key, toSort []Key) []Key {
-	toSortCopy := make([]Key, len(toSort))
-	copy(toSortCopy, toSort)
-	bdtc := &byDistanceToCenter{
-		Center: center,
-		Keys:   toSortCopy, // copy
-	}
-	sort.Sort(bdtc)
-	return bdtc.Keys
+	toSortCopy := slices.Clone(toSort)
+	slices.SortFunc(toSortCopy, func(a, b Key) int {
+		return center.Distance(a).Cmp(center.Distance(b))
+	})
+	return toSortCopy
 }

--- a/keyspace/keyspace.go
+++ b/keyspace/keyspace.go
@@ -33,14 +33,6 @@ func (k1 Key) Equal(k2 Key) bool {
 	return k1.Space.Equal(k1, k2)
 }
 
-// Less returns whether this key comes before another.
-func (k1 Key) Less(k2 Key) bool {
-	if k1.Space != k2.Space {
-		panic("k1 and k2 not in same key space.")
-	}
-	return k1.Space.Less(k1, k2)
-}
-
 // Distance returns this key's distance to another
 func (k1 Key) Distance(k2 Key) *big.Int {
 	if k1.Space != k2.Space {
@@ -60,8 +52,6 @@ type KeySpace interface {
 	Distance(Key, Key) *big.Int
 	// Cmp returns an integer comparing two keys.
 	Cmp(Key, Key) int
-	// Less returns whether the first key is smaller than the second.
-	Less(Key, Key) bool
 }
 
 // SortByDistance takes a KeySpace, a center Key, and a list of Keys toSort.

--- a/keyspace/keyspace.go
+++ b/keyspace/keyspace.go
@@ -17,12 +17,12 @@ type Key struct {
 	Bytes []byte
 }
 
-// Cmp returns an integer that compares the two Keys.
-func (k1 Key) Cmp(k2 Key) int {
+// Compare returns an integer that compares the two Keys.
+func (k1 Key) Compare(k2 Key) int {
 	if k1.Space != k2.Space {
 		panic("k1 and k2 not in same key space.")
 	}
-	return k1.Space.Cmp(k1, k2)
+	return k1.Space.Compare(k1, k2)
 }
 
 // Equal returns whether this key is equal to another.
@@ -50,8 +50,8 @@ type KeySpace interface {
 	Equal(Key, Key) bool
 	// Distance returns the distance metric in this key space
 	Distance(Key, Key) *big.Int
-	// Cmp returns an integer comparing two keys.
-	Cmp(Key, Key) int
+	// Compare returns an integer comparing two keys.
+	Compare(Key, Key) int
 }
 
 // keyDistance holds a Key alongside its precomputed distance to a center Key.

--- a/keyspace/keyspace.go
+++ b/keyspace/keyspace.go
@@ -54,13 +54,26 @@ type KeySpace interface {
 	Cmp(Key, Key) int
 }
 
+// keyDistance holds a Key alongside its precomputed distance to a center Key.
+type keyDistance struct {
+	key      Key
+	distance *big.Int
+}
+
 // SortByDistance takes a KeySpace, a center Key, and a list of Keys toSort.
 // It returns a new list, where the Keys toSort have been sorted by their
 // distance to the center Key.
 func SortByDistance(sp KeySpace, center Key, toSort []Key) []Key {
-	toSortCopy := slices.Clone(toSort)
-	slices.SortFunc(toSortCopy, func(a, b Key) int {
-		return center.Distance(a).Cmp(center.Distance(b))
+	distances := make([]keyDistance, len(toSort))
+	for i, k := range toSort {
+		distances[i] = keyDistance{key: k, distance: center.Distance(k)}
+	}
+	slices.SortFunc(distances, func(a, b keyDistance) int {
+		return a.distance.Cmp(b.distance)
 	})
-	return toSortCopy
+	sorted := make([]Key, len(distances))
+	for i, d := range distances {
+		sorted[i] = d.key
+	}
+	return sorted
 }

--- a/keyspace/sort_test.go
+++ b/keyspace/sort_test.go
@@ -1,0 +1,66 @@
+package keyspace
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math/rand/v2"
+	"slices"
+	"strconv"
+	"testing"
+)
+
+func randKeys(rng *rand.Rand, n int) []Key {
+	keys := make([]Key, n)
+	for i := range keys {
+		buf := make([]byte, 16)
+		binary.BigEndian.PutUint64(buf, rng.Uint64())
+		binary.BigEndian.PutUint64(buf[8:], rng.Uint64())
+		keys[i] = XORKeySpace.Key(buf)
+	}
+	return keys
+}
+
+func TestSortByDistanceIsSorted(t *testing.T) {
+	for _, n := range []int{0, 1, 2, 3, 17, 200} {
+		keys := randKeys(rand.New(rand.NewPCG(99, 99)), n)
+		center := XORKeySpace.Key([]byte("center"))
+
+		sorted := SortByDistance(XORKeySpace, center, keys)
+
+		if len(sorted) != n {
+			t.Fatalf("n=%d: got %d keys, want %d", n, len(sorted), n)
+		}
+		for i := 1; i < len(sorted); i++ {
+			if center.Distance(sorted[i-1]).Cmp(center.Distance(sorted[i])) > 0 {
+				t.Fatalf("n=%d: not sorted at index %d", n, i)
+			}
+		}
+	}
+}
+
+func TestSortByDistanceDoesNotMutateInput(t *testing.T) {
+	keys := randKeys(rand.New(rand.NewPCG(7, 7)), 64)
+	original := slices.Clone(keys)
+	center := XORKeySpace.Key([]byte("center"))
+
+	SortByDistance(XORKeySpace, center, keys)
+
+	for i := range keys {
+		if !bytes.Equal(keys[i].Bytes, original[i].Bytes) {
+			t.Fatalf("input mutated at index %d", i)
+		}
+	}
+}
+
+func BenchmarkSortByDistance(b *testing.B) {
+	center := XORKeySpace.Key([]byte("center"))
+	for _, n := range []int{16, 64, 256, 1024} {
+		keys := randKeys(rand.New(rand.NewPCG(1, 1)), n)
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				SortByDistance(XORKeySpace, center, keys)
+			}
+		})
+	}
+}

--- a/keyspace/xor.go
+++ b/keyspace/xor.go
@@ -27,6 +27,13 @@ func (s *xorKeySpace) Key(id []byte) Key {
 		Original: id,
 		Bytes:    key,
 	}
+
+}
+
+// Cmp eturns an integer comparing two keys in this key space.The result will
+// be 0 if k1 == k2, -1 if k1 < k2, and +1 if k1 > k2.
+func (s *xorKeySpace) Cmp(k1, k2 Key) int {
+	return bytes.Compare(k1.Bytes, k2.Bytes)
 }
 
 // Equal returns whether keys are equal in this key space

--- a/keyspace/xor.go
+++ b/keyspace/xor.go
@@ -51,11 +51,6 @@ func (s *xorKeySpace) Distance(k1, k2 Key) *big.Int {
 	return dist
 }
 
-// Less returns whether the first key is smaller than the second.
-func (s *xorKeySpace) Less(k1, k2 Key) bool {
-	return bytes.Compare(k1.Bytes, k2.Bytes) < 0
-}
-
 // ZeroPrefixLen returns the number of consecutive zeroes in a byte slice.
 func ZeroPrefixLen(id []byte) int {
 	for i, b := range id {

--- a/keyspace/xor.go
+++ b/keyspace/xor.go
@@ -30,7 +30,7 @@ func (s *xorKeySpace) Key(id []byte) Key {
 
 }
 
-// Cmp eturns an integer comparing two keys in this key space.The result will
+// Cmp returns an integer comparing two keys in this key space. The result will
 // be 0 if k1 == k2, -1 if k1 < k2, and +1 if k1 > k2.
 func (s *xorKeySpace) Cmp(k1, k2 Key) int {
 	return bytes.Compare(k1.Bytes, k2.Bytes)

--- a/keyspace/xor.go
+++ b/keyspace/xor.go
@@ -30,9 +30,9 @@ func (s *xorKeySpace) Key(id []byte) Key {
 
 }
 
-// Cmp returns an integer comparing two keys in this key space. The result will
-// be 0 if k1 == k2, -1 if k1 < k2, and +1 if k1 > k2.
-func (s *xorKeySpace) Cmp(k1, k2 Key) int {
+// Compare returns an integer comparing two keys in this key space. The result
+// will be 0 if k1 == k2, -1 if k1 < k2, and +1 if k1 > k2.
+func (s *xorKeySpace) Compare(k1, k2 Key) int {
 	return bytes.Compare(k1.Bytes, k2.Bytes)
 }
 

--- a/keyspace/xor_test.go
+++ b/keyspace/xor_test.go
@@ -56,7 +56,7 @@ func TestXorKeySpace(t *testing.T) {
 	for i := 1; i < len(ks); i++ {
 		keyA := ks[i][0]
 		keyB := ks[i-1][0]
-		if keyB.Cmp(keyA) == keyA.Cmp(keyB) {
+		if keyB.Compare(keyA) == keyA.Compare(keyB) {
 			t.Errorf("less should be different.")
 		}
 

--- a/keyspace/xor_test.go
+++ b/keyspace/xor_test.go
@@ -54,16 +54,18 @@ func TestXorKeySpace(t *testing.T) {
 	}
 
 	for i := 1; i < len(ks); i++ {
-		if ks[i][0].Less(ks[i-1][0]) == ks[i-1][0].Less(ks[i][0]) {
+		keyA := ks[i][0]
+		keyB := ks[i-1][0]
+		if keyB.Cmp(keyA) == keyA.Cmp(keyB) {
 			t.Errorf("less should be different.")
 		}
 
-		if ks[i][0].Distance(ks[i-1][0]).Cmp(ks[i-1][0].Distance(ks[i][0])) != 0 {
+		if keyB.Distance(keyA).Cmp(keyA.Distance(keyB)) != 0 {
 			t.Errorf("distance should be the same.")
 		}
 
-		if ks[i][0].Equal(ks[i-1][0]) {
-			t.Errorf("Keys should not be eq. %v != %v", ks[i][0], ks[i-1][0])
+		if keyB.Equal(keyA) {
+			t.Errorf("Keys should not be eq. %v != %v", keyB, keyA)
 		}
 	}
 }

--- a/sorting.go
+++ b/sorting.go
@@ -38,7 +38,7 @@ func (pds *peerDistanceSorter) appendPeersFromList(l *list.List) {
 
 func (pds *peerDistanceSorter) sort() {
 	slices.SortFunc(pds.peers, func(a, b peerDistance) int {
-		return a.distance.cmp(b.distance)
+		return a.distance.compare(b.distance)
 	})
 }
 

--- a/sorting.go
+++ b/sorting.go
@@ -2,7 +2,7 @@ package kbucket
 
 import (
 	"container/list"
-	"sort"
+	"slices"
 
 	"github.com/libp2p/go-libp2p/core/peer"
 )
@@ -20,13 +20,6 @@ type peerDistanceSorter struct {
 }
 
 func (pds *peerDistanceSorter) Len() int { return len(pds.peers) }
-func (pds *peerDistanceSorter) Swap(a, b int) {
-	pds.peers[a], pds.peers[b] = pds.peers[b], pds.peers[a]
-}
-
-func (pds *peerDistanceSorter) Less(a, b int) bool {
-	return pds.peers[a].distance.less(pds.peers[b].distance)
-}
 
 // Append the peer.ID to the sorter's slice. It may no longer be sorted.
 func (pds *peerDistanceSorter) appendPeer(p peer.ID, pDhtId ID) {
@@ -44,22 +37,19 @@ func (pds *peerDistanceSorter) appendPeersFromList(l *list.List) {
 }
 
 func (pds *peerDistanceSorter) sort() {
-	sort.Sort(pds)
+	slices.SortFunc(pds.peers, func(a, b peerDistance) int {
+		return a.distance.cmp(b.distance)
+	})
 }
 
-// SortClosestPeers Sort the given peers by their ascending distance from the target. A new slice is returned.
+// SortClosestPeers sorts the given peers by their ascending distance from the
+// target. A new slice is returned.
 func SortClosestPeers(peers []peer.ID, target ID) []peer.ID {
-	sorter := peerDistanceSorter{
-		peers:  make([]peerDistance, 0, len(peers)),
-		target: target,
-	}
-	for _, p := range peers {
-		sorter.appendPeer(p, ConvertPeerID(p))
-	}
-	sorter.sort()
-	out := make([]peer.ID, 0, sorter.Len())
-	for _, p := range sorter.peers {
-		out = append(out, p.p)
-	}
+	out := slices.Clone(peers)
+	slices.SortFunc(out, func(a, b peer.ID) int {
+		aDist := Xor(target, ConvertPeerID(a))
+		bDist := Xor(target, ConvertPeerID(b))
+		return aDist.cmp(bDist)
+	})
 	return out
 }

--- a/sorting.go
+++ b/sorting.go
@@ -13,7 +13,7 @@ type peerDistance struct {
 	distance ID
 }
 
-// peerDistanceSorter implements sort.Interface to sort peers by xor distance
+// peerDistanceSorter sorts peers by xor distance to a target.
 type peerDistanceSorter struct {
 	peers  []peerDistance
 	target ID
@@ -45,11 +45,18 @@ func (pds *peerDistanceSorter) sort() {
 // SortClosestPeers sorts the given peers by their ascending distance from the
 // target. A new slice is returned.
 func SortClosestPeers(peers []peer.ID, target ID) []peer.ID {
-	out := slices.Clone(peers)
-	slices.SortFunc(out, func(a, b peer.ID) int {
-		aDist := Xor(target, ConvertPeerID(a))
-		bDist := Xor(target, ConvertPeerID(b))
-		return aDist.cmp(bDist)
-	})
+	sorter := peerDistanceSorter{
+		peers:  make([]peerDistance, 0, len(peers)),
+		target: target,
+	}
+	for _, p := range peers {
+		sorter.appendPeer(p, ConvertPeerID(p))
+	}
+	sorter.sort()
+
+	out := make([]peer.ID, 0, sorter.Len())
+	for _, p := range sorter.peers {
+		out = append(out, p.p)
+	}
 	return out
 }

--- a/sorting_test.go
+++ b/sorting_test.go
@@ -1,0 +1,57 @@
+package kbucket
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/test"
+)
+
+func randPeers(t testing.TB, n int) []peer.ID {
+	t.Helper()
+	peers := make([]peer.ID, n)
+	for i := range peers {
+		p, err := test.RandPeerID()
+		if err != nil {
+			t.Fatal(err)
+		}
+		peers[i] = p
+	}
+	return peers
+}
+
+func TestSortClosestPeersIsSorted(t *testing.T) {
+	target := ConvertPeerID(randPeers(t, 1)[0])
+
+	for _, n := range []int{0, 1, 2, 3, 17, 200} {
+		peers := randPeers(t, n)
+
+		sorted := SortClosestPeers(peers, target)
+
+		if len(sorted) != n {
+			t.Fatalf("n=%d: got %d peers, want %d", n, len(sorted), n)
+		}
+		for i := 1; i < len(sorted); i++ {
+			prev := Xor(target, ConvertPeerID(sorted[i-1]))
+			cur := Xor(target, ConvertPeerID(sorted[i]))
+			if prev.cmp(cur) > 0 {
+				t.Fatalf("n=%d: not sorted at index %d", n, i)
+			}
+		}
+	}
+}
+
+func TestSortClosestPeersDoesNotMutateInput(t *testing.T) {
+	peers := randPeers(t, 64)
+	original := slices.Clone(peers)
+	target := ConvertPeerID(peers[0])
+
+	SortClosestPeers(peers, target)
+
+	for i := range peers {
+		if peers[i] != original[i] {
+			t.Fatalf("input mutated at index %d", i)
+		}
+	}
+}

--- a/sorting_test.go
+++ b/sorting_test.go
@@ -35,7 +35,7 @@ func TestSortClosestPeersIsSorted(t *testing.T) {
 		for i := 1; i < len(sorted); i++ {
 			prev := Xor(target, ConvertPeerID(sorted[i-1]))
 			cur := Xor(target, ConvertPeerID(sorted[i]))
-			if prev.cmp(cur) > 0 {
+			if prev.compare(cur) > 0 {
 				t.Fatalf("n=%d: not sorted at index %d", n, i)
 			}
 		}

--- a/util.go
+++ b/util.go
@@ -26,10 +26,10 @@ const PeerIDPreimageMaxCpl uint = 15
 // peer.ID or a util.Key. This unifies the keyspace
 type ID []byte
 
-func (id ID) less(other ID) bool {
+func (id ID) cmp(other ID) int {
 	a := ks.Key{Space: ks.XORKeySpace, Bytes: id}
 	b := ks.Key{Space: ks.XORKeySpace, Bytes: other}
-	return a.Less(b)
+	return a.Cmp(b)
 }
 
 func Xor(a, b ID) ID {
@@ -60,7 +60,7 @@ func Closer(a, b peer.ID, key string) bool {
 	adist := Xor(aid, tgt)
 	bdist := Xor(bid, tgt)
 
-	return adist.less(bdist)
+	return adist.cmp(bdist) < 0
 }
 
 // GenRandPeerID generates a random peerID sharing a common prefix of length

--- a/util.go
+++ b/util.go
@@ -1,6 +1,7 @@
 package kbucket
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -26,10 +27,10 @@ const PeerIDPreimageMaxCpl uint = 15
 // peer.ID or a util.Key. This unifies the keyspace
 type ID []byte
 
+// cmp compares two IDs in the XOR keyspace, where the distance ordering is
+// the lexicographic ordering of the raw bytes.
 func (id ID) cmp(other ID) int {
-	a := ks.Key{Space: ks.XORKeySpace, Bytes: id}
-	b := ks.Key{Space: ks.XORKeySpace, Bytes: other}
-	return a.Cmp(b)
+	return bytes.Compare(id, other)
 }
 
 func Xor(a, b ID) ID {

--- a/util.go
+++ b/util.go
@@ -27,9 +27,9 @@ const PeerIDPreimageMaxCpl uint = 15
 // peer.ID or a util.Key. This unifies the keyspace
 type ID []byte
 
-// cmp compares two IDs in the XOR keyspace, where the distance ordering is
+// compare compares two IDs in the XOR keyspace, where the distance ordering is
 // the lexicographic ordering of the raw bytes.
-func (id ID) cmp(other ID) int {
+func (id ID) compare(other ID) int {
 	return bytes.Compare(id, other)
 }
 
@@ -61,7 +61,7 @@ func Closer(a, b peer.ID, key string) bool {
 	adist := Xor(aid, tgt)
 	bdist := Xor(bid, tgt)
 
-	return adist.cmp(bdist) < 0
+	return adist.compare(bdist) < 0
 }
 
 // GenRandPeerID generates a random peerID sharing a common prefix of length

--- a/util_test.go
+++ b/util_test.go
@@ -15,7 +15,7 @@ func TestCloser(t *testing.T) {
 	// returns true if d(Pa, X) < d(Pb, X)
 	for {
 		X = string(test.RandPeerIDFatal(t))
-		if Xor(ConvertPeerID(Pa), ConvertKey(X)).cmp(Xor(ConvertPeerID(Pb), ConvertKey(X))) < 0 {
+		if Xor(ConvertPeerID(Pa), ConvertKey(X)).compare(Xor(ConvertPeerID(Pb), ConvertKey(X))) < 0 {
 			break
 		}
 	}
@@ -25,7 +25,7 @@ func TestCloser(t *testing.T) {
 	// returns false if d(Pa,X) > d(Pb, X)
 	for {
 		X = string(test.RandPeerIDFatal(t))
-		if Xor(ConvertPeerID(Pb), ConvertKey(X)).cmp(Xor(ConvertPeerID(Pa), ConvertKey(X))) < 0 {
+		if Xor(ConvertPeerID(Pb), ConvertKey(X)).compare(Xor(ConvertPeerID(Pa), ConvertKey(X))) < 0 {
 			break
 		}
 

--- a/util_test.go
+++ b/util_test.go
@@ -15,7 +15,7 @@ func TestCloser(t *testing.T) {
 	// returns true if d(Pa, X) < d(Pb, X)
 	for {
 		X = string(test.RandPeerIDFatal(t))
-		if Xor(ConvertPeerID(Pa), ConvertKey(X)).less(Xor(ConvertPeerID(Pb), ConvertKey(X))) {
+		if Xor(ConvertPeerID(Pa), ConvertKey(X)).cmp(Xor(ConvertPeerID(Pb), ConvertKey(X))) < 0 {
 			break
 		}
 	}
@@ -25,7 +25,7 @@ func TestCloser(t *testing.T) {
 	// returns false if d(Pa,X) > d(Pb, X)
 	for {
 		X = string(test.RandPeerIDFatal(t))
-		if Xor(ConvertPeerID(Pb), ConvertKey(X)).less(Xor(ConvertPeerID(Pa), ConvertKey(X))) {
+		if Xor(ConvertPeerID(Pb), ConvertKey(X)).cmp(Xor(ConvertPeerID(Pa), ConvertKey(X))) < 0 {
 			break
 		}
 


### PR DESCRIPTION
Replacing the Sort interface with slices.Sort results in less code and is slightly more efficient.